### PR TITLE
feat: Why-this-stop chips + free-tier usage badge

### DIFF
--- a/src/components/EntitlementsBadge.tsx
+++ b/src/components/EntitlementsBadge.tsx
@@ -1,0 +1,55 @@
+import { Show, createMemo } from "solid-js";
+import { A } from "@solidjs/router";
+import { useLists } from "~/lib/api/lists";
+import { useFavoritesList } from "~/lib/api/favorites";
+import { useUserSubscription } from "~/lib/api/billing";
+import { isProPlan } from "~/lib/subscription";
+
+/** Free-tier caps — keep in sync with server subscription/entitlements.go + PRICING.md */
+export const FREE_MAX_LISTS = 5;
+export const FREE_MAX_PLACES = 50;
+
+/**
+ * Shows free-tier list/place usage (e.g. Lists 2/5 · Saves 12/50).
+ * Hidden for Pro or when unauthenticated queries return empty.
+ */
+export default function EntitlementsBadge() {
+  const subscription = useUserSubscription();
+  const lists = useLists();
+  const favorites = useFavoritesList();
+
+  const isPro = () => isProPlan(subscription.data?.plan);
+
+  const listCount = createMemo(() => (lists.data ?? []).length);
+  const placeCount = createMemo(() => {
+    const favs = favorites.data?.items?.length ?? 0;
+    // List item totals aren't in GetLists payload cheaply — favorites alone is
+    // the visible "saves" signal until EntitlementService lands.
+    return favs;
+  });
+
+  const nearListLimit = () => !isPro() && listCount() >= FREE_MAX_LISTS - 1;
+  const nearPlaceLimit = () => !isPro() && placeCount() >= FREE_MAX_PLACES - 5;
+
+  return (
+    <Show when={!isPro() && (listCount() > 0 || placeCount() > 0)}>
+      <A
+        href="/pricing"
+        class={`hidden sm:inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors hover:border-primary/40 ${
+          nearListLimit() || nearPlaceLimit()
+            ? "border-amber-400/50 bg-amber-500/10 text-amber-800 dark:text-amber-200"
+            : "border-border bg-muted/40 text-muted-foreground"
+        }`}
+        title="Free plan usage — upgrade for unlimited saves"
+      >
+        <span>
+          Lists {listCount()}/{FREE_MAX_LISTS}
+        </span>
+        <span class="opacity-40">·</span>
+        <span>
+          Saves {placeCount()}/{FREE_MAX_PLACES}
+        </span>
+      </A>
+    </Show>
+  );
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -24,6 +24,7 @@ import { ImageRoot, ImageFallback, Image } from "@/ui/image";
 import { useAuth } from "~/contexts/AuthContext";
 import PWAInstall from "~/components/PWAInstall";
 import ThemeSelector from "~/components/ThemeSelector";
+import EntitlementsBadge from "~/components/EntitlementsBadge";
 import { handleLinkPreload } from "~/lib/preload";
 
 // Public navigation items (for non-authenticated users)
@@ -172,6 +173,7 @@ export default function Nav() {
                     );
                   }}
                 </For>
+                <EntitlementsBadge />
               </div>
             </Show>
           </Show>

--- a/src/components/poi/WhyThisStop.tsx
+++ b/src/components/poi/WhyThisStop.tsx
@@ -1,0 +1,27 @@
+import { Show } from "solid-js";
+import { Sparkles } from "lucide-solid";
+
+export interface WhyThisStopProps {
+  /** Short rationale text. Hidden when empty. */
+  reason?: string | null;
+  class?: string;
+}
+
+/** Compact transparency chip — "Why this stop". */
+export default function WhyThisStop(props: WhyThisStopProps) {
+  const text = () => props.reason?.trim() ?? "";
+  return (
+    <Show when={text()}>
+      <p
+        class={`mt-1.5 inline-flex max-w-full items-start gap-1.5 rounded-md border border-primary/20 bg-primary/5 px-2 py-1 text-xs text-foreground/80 ${props.class ?? ""}`}
+        title="Why Loci suggested this"
+      >
+        <Sparkles class="mt-0.5 h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
+        <span class="min-w-0">
+          <span class="font-medium text-primary">Why this: </span>
+          {text()}
+        </span>
+      </p>
+    </Show>
+  );
+}

--- a/src/components/results/ItineraryResults.tsx
+++ b/src/components/results/ItineraryResults.tsx
@@ -10,6 +10,8 @@ import {
   Share2,
 } from "lucide-solid";
 import FavoriteButton from "~/components/shared/FavoriteButton";
+import WhyThisStop from "~/components/poi/WhyThisStop";
+import { deriveWhyThis } from "~/lib/why-this";
 import { POIDetailedInfo, AIItineraryResponse } from "~/lib/api/types";
 
 interface ItineraryResultsProps {
@@ -187,9 +189,7 @@ export default function ItineraryResults(props: ItineraryResultsProps) {
                     <Show when={poi.rating}>
                       <div class="flex items-center gap-1 ml-2 flex-shrink-0">
                         <Star class="w-4 h-4 text-accent fill-current" />
-                        <span class="text-sm font-medium text-foreground">
-                          {poi.rating}
-                        </span>
+                        <span class="text-sm font-medium text-foreground">{poi.rating}</span>
                       </div>
                     </Show>
                   </div>
@@ -198,6 +198,21 @@ export default function ItineraryResults(props: ItineraryResultsProps) {
                     <p class="text-sm text-muted-foreground mb-3 line-clamp-2">
                       {poi.description_poi}
                     </p>
+                  </Show>
+
+                  <Show when={!props.compact}>
+                    <WhyThisStop
+                      reason={deriveWhyThis({
+                        category: poi.category,
+                        rating: poi.rating,
+                        recommendation_rationale: (
+                          poi as POIDetailedInfo & {
+                            recommendation_rationale?: string;
+                          }
+                        ).recommendation_rationale,
+                        tags: poi.tags,
+                      })}
+                    />
                   </Show>
 
                   <div class="flex items-center gap-4 text-xs text-muted-foreground flex-wrap">

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -614,6 +614,8 @@ export interface POIDetailedInfo {
   reviewCount?: number;
   cuisine_type?: string;
   star_rating?: number;
+  recommendation_rationale?: string;
+  uncertainty_score?: number;
 }
 
 // Domain-specific response types

--- a/src/lib/why-this.test.ts
+++ b/src/lib/why-this.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { deriveWhyThis } from "./why-this";
+
+describe("deriveWhyThis", () => {
+  it("prefers server rationale", () => {
+    expect(
+      deriveWhyThis({
+        category: "museum",
+        rating: 4.8,
+        recommendation_rationale: "Matches your foodie profile.",
+      }),
+    ).toBe("Matches your foodie profile.");
+  });
+
+  it("falls back to high-rated category copy", () => {
+    expect(deriveWhyThis({ category: "cafe", rating: 4.2 })).toBe(
+      "Highly rated cafe that fits your search.",
+    );
+  });
+
+  it("falls back to category matching prefs", () => {
+    expect(deriveWhyThis({ category: "park", rating: 3.1 })).toBe(
+      "A park matching your preferences.",
+    );
+  });
+
+  it("returns undefined when empty", () => {
+    expect(deriveWhyThis({})).toBeUndefined();
+  });
+});

--- a/src/lib/why-this.ts
+++ b/src/lib/why-this.ts
@@ -1,0 +1,29 @@
+// Client-side "why this stop" helpers. Mirror server TrustSignals until the
+// published BSR client package includes recommendation_rationale.
+
+export interface WhyThisInput {
+  category?: string | null;
+  rating?: number | null;
+  recommendation_rationale?: string | null;
+  tags?: string[] | null;
+}
+
+/** Short human rationale for a POI / trip stop. */
+export function deriveWhyThis(input: WhyThisInput): string | undefined {
+  const fromServer = input.recommendation_rationale?.trim();
+  if (fromServer) return fromServer;
+
+  const category = input.category?.trim();
+  const rating = input.rating ?? 0;
+  if (rating >= 4.0 && category) {
+    return `Highly rated ${category} that fits your search.`;
+  }
+  if (category) {
+    return `A ${category} matching your preferences.`;
+  }
+  const tag = input.tags?.find((t) => t.trim());
+  if (tag) {
+    return `Suggested because of your interest in ${tag}.`;
+  }
+  return undefined;
+}

--- a/src/routes/trips/[id].tsx
+++ b/src/routes/trips/[id].tsx
@@ -16,6 +16,7 @@ import { TripPace } from "@buf/loci_loci-proto.bufbuild_es/loci/trip/trip_pb.js"
 import { useUserSubscription } from "~/lib/api/billing";
 import { isProPlan } from "~/lib/subscription";
 import TripExportMenu from "~/components/trip/TripExportMenu";
+import WhyThisStop from "~/components/poi/WhyThisStop";
 
 const minutesToHHMM = (m?: number) => {
   if (m == null) return "";
@@ -294,11 +295,9 @@ export default function TripEditor() {
                             />
                             <span class="text-xs text-muted-foreground">min</span>
                           </div>
-                          <Show when={stop.notes}>
-                            <p class="mt-2 pl-8 text-xs text-muted-foreground line-clamp-2">
-                              {stop.notes}
-                            </p>
-                          </Show>
+                          <div class="mt-1 pl-8">
+                            <WhyThisStop reason={stop.notes} />
+                          </div>
                         </li>
                       )}
                     </For>


### PR DESCRIPTION
## Summary
- `WhyThisStop` chip on itinerary results + trip editor stops
- Client `deriveWhyThis` mirrors server TrustSignals until BSR ships `recommendation_rationale`
- Nav `EntitlementsBadge` shows free Lists/Saves usage → `/pricing`

## Test plan
- [x] `tsc --noEmit`
- [x] `vitest run src/lib/why-this.test.ts`
- [ ] Discover itinerary cards show Why chip
- [ ] Trip editor shows Why chip from stop notes (needs server PR)
- [ ] Free user with lists/favorites sees nav usage badge


Made with [Cursor](https://cursor.com)