### PR TITLE
feat: Markdown export + offline trip cache

### DIFF
--- a/src/components/trip/TripExportMenu.tsx
+++ b/src/components/trip/TripExportMenu.tsx
@@ -1,21 +1,24 @@
 import { createSignal, Show } from "solid-js";
 import { A } from "@solidjs/router";
-import { CalendarPlus, Crown, Download, Lock } from "lucide-solid";
-import { exportTripICS, exportTripPDF } from "~/lib/api/trips";
+import { CalendarPlus, Crown, Download, FileText, Lock } from "lucide-solid";
+import { exportTripICS, exportTripPDF, type Trip } from "~/lib/api/trips";
+import { downloadTripMarkdown } from "~/lib/trip-markdown";
 import { showUpgradePrompt } from "~/lib/upgrade-prompt";
 
 export interface TripExportMenuProps {
   tripId: string;
   dayCount: number;
   isPro: boolean;
+  /** Full trip — required for client-side Markdown export. */
+  trip?: Trip;
 }
 
 /**
  * ICS always available. Full multi-day PDF is Pro; free users get Day-1 tease
- * via upgrade prompt when dayCount > 1.
+ * via upgrade prompt when dayCount > 1. Markdown is Pro-only (PRICING.md).
  */
 export default function TripExportMenu(props: TripExportMenuProps) {
-  const [busy, setBusy] = createSignal<"ics" | "pdf" | null>(null);
+  const [busy, setBusy] = createSignal<"ics" | "pdf" | "md" | null>(null);
   const [toast, setToast] = createSignal<string | null>(null);
 
   const flash = (msg: string) => {
@@ -60,6 +63,26 @@ export default function TripExportMenu(props: TripExportMenuProps) {
     }
   };
 
+  const handleMarkdown = () => {
+    if (!props.isPro) {
+      showUpgradePrompt("entitlement", "Markdown itinerary export is included with Pro.");
+      return;
+    }
+    if (!props.trip) {
+      flash("Trip still loading — try again in a moment.");
+      return;
+    }
+    setBusy("md");
+    try {
+      downloadTripMarkdown(props.trip);
+      flash("Markdown downloaded.");
+    } catch (e) {
+      flash(e instanceof Error ? e.message : "Markdown export failed");
+    } finally {
+      setBusy(null);
+    }
+  };
+
   return (
     <div class="relative flex flex-wrap items-center gap-2">
       <button
@@ -82,6 +105,21 @@ export default function TripExportMenu(props: TripExportMenuProps) {
         </Show>
         {busy() === "pdf" ? "…" : "PDF"}
         <Show when={!props.isPro && props.dayCount > 1}>
+          <Crown class="h-3.5 w-3.5 text-amber-500" />
+        </Show>
+      </button>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
+        disabled={busy() !== null}
+        onClick={handleMarkdown}
+        title={props.isPro ? "Download Markdown" : "Pro: Markdown export"}
+      >
+        <Show when={props.isPro} fallback={<Lock class="h-4 w-4" />}>
+          <FileText class="h-4 w-4" />
+        </Show>
+        {busy() === "md" ? "…" : ".md"}
+        <Show when={!props.isPro}>
           <Crown class="h-3.5 w-3.5 text-amber-500" />
         </Show>
       </button>

--- a/src/lib/api/trips.ts
+++ b/src/lib/api/trips.ts
@@ -23,6 +23,7 @@ import {
 } from "@buf/loci_loci-proto.bufbuild_es/loci/trip/trip_pb.js";
 import { PaginationRequestSchema } from "@buf/loci_loci-proto.bufbuild_es/loci/common/common_pb.js";
 import { transport } from "../connect-transport";
+import { cacheTripOffline, getCachedTrip } from "../trip-offline-cache";
 
 const tripClient = createClient(TripService, transport);
 
@@ -177,8 +178,13 @@ export const useTrip = (id: () => string | undefined) =>
     enabled: !!id(),
     queryFn: async () => {
       const res = await tripClient.getTrip(create(GetTripRequestSchema, { tripId: id()! }));
-      return mapTrip(res);
+      const trip = mapTrip(res);
+      cacheTripOffline(trip);
+      return trip;
     },
+    // Serve last cached copy while offline / before network returns.
+    placeholderData: () => getCachedTrip(id() ?? ""),
+    networkMode: "offlineFirst",
   }));
 
 // ---- mutations ----

--- a/src/lib/trip-markdown.test.ts
+++ b/src/lib/trip-markdown.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { TripPace } from "@buf/loci_loci-proto.bufbuild_es/loci/trip/trip_pb.js";
+import type { Trip } from "~/lib/api/trips";
+import { tripToMarkdown } from "./trip-markdown";
+
+const sample: Trip = {
+  id: "t1",
+  userId: "u1",
+  cityName: "Lisbon",
+  title: "Weekend in Lisbon",
+  constraints: {
+    pace: TripPace.MODERATE,
+    mobility: "walking",
+    interests: ["food", "history"],
+  },
+  version: 1n,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-02T00:00:00.000Z",
+  days: [
+    {
+      id: "d1",
+      dayNumber: 1,
+      stops: [
+        {
+          id: "s1",
+          poiId: "p1",
+          orderIndex: 0,
+          name: "Time Out Market",
+          startMinute: 12 * 60,
+          durationMinutes: 90,
+          notes: "Highly rated market that fits your search.",
+        },
+      ],
+    },
+  ],
+};
+
+describe("tripToMarkdown", () => {
+  it("includes title city and why-this notes", () => {
+    const md = tripToMarkdown(sample);
+    expect(md).toContain("# Weekend in Lisbon");
+    expect(md).toContain("Lisbon");
+    expect(md).toContain("Time Out Market");
+    expect(md).toContain("Why this:");
+    expect(md).toContain("## Day 1");
+  });
+});

--- a/src/lib/trip-markdown.ts
+++ b/src/lib/trip-markdown.ts
@@ -1,0 +1,63 @@
+import type { Trip, TripDay, TripStop } from "~/lib/api/trips";
+import { TripPace } from "@buf/loci_loci-proto.bufbuild_es/loci/trip/trip_pb.js";
+
+const PACE: Record<number, string> = {
+  [TripPace.UNSPECIFIED]: "",
+  [TripPace.RELAXED]: "Relaxed",
+  [TripPace.MODERATE]: "Moderate",
+  [TripPace.PACKED]: "Packed",
+};
+
+function minutesLabel(m?: number): string {
+  if (m == null) return "";
+  const h = Math.floor(m / 60);
+  const mm = m % 60;
+  return `${String(h).padStart(2, "0")}:${String(mm).padStart(2, "0")}`;
+}
+
+function stopLine(s: TripStop): string {
+  const time = minutesLabel(s.startMinute);
+  const dur = s.durationMinutes ? ` (${s.durationMinutes} min)` : "";
+  const head = time ? `- **${time}** ${s.name}${dur}` : `- ${s.name}${dur}`;
+  if (s.notes?.trim()) {
+    return `${head}\n  - _Why this:_ ${s.notes.trim()}`;
+  }
+  return head;
+}
+
+function daySection(d: TripDay): string {
+  const date = d.date ? ` — ${new Date(d.date).toLocaleDateString()}` : "";
+  const stops = d.stops.map(stopLine).join("\n");
+  return `## Day ${d.dayNumber}${date}\n\n${stops || "_No stops._"}\n`;
+}
+
+/** Render an editable trip as Markdown (Pro export — client-side until proto MARKDOWN lands). */
+export function tripToMarkdown(trip: Trip): string {
+  const lines: string[] = [`# ${trip.title}`, ""];
+  if (trip.cityName) lines.push(`**City:** ${trip.cityName}`);
+  const pace = PACE[trip.constraints.pace];
+  if (pace) lines.push(`**Pace:** ${pace}`);
+  if (trip.constraints.mobility) lines.push(`**Mobility:** ${trip.constraints.mobility}`);
+  if (trip.constraints.interests?.length) {
+    lines.push(`**Interests:** ${trip.constraints.interests.join(", ")}`);
+  }
+  lines.push("", `*Exported from Loci · updated ${new Date(trip.updatedAt).toLocaleString()}*`, "");
+  for (const day of trip.days) {
+    lines.push(daySection(day));
+  }
+  return lines.join("\n").trim() + "\n";
+}
+
+export function downloadTripMarkdown(trip: Trip): void {
+  const md = tripToMarkdown(trip);
+  const blob = new Blob([md], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  const safe = (trip.title || "trip").replace(/[^\w-]+/g, "_").slice(0, 80);
+  a.download = `${safe || "trip"}.md`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/trip-offline-cache.ts
+++ b/src/lib/trip-offline-cache.ts
@@ -1,0 +1,88 @@
+import type { Trip } from "~/lib/api/trips";
+
+const STORAGE_KEY = "loci.offline.trips.v1";
+const MAX_TRIPS = 12;
+
+export interface CachedTripSummary {
+  id: string;
+  title: string;
+  cityName: string;
+  dayCount: number;
+  updatedAt: string;
+}
+
+interface CacheFile {
+  trips: Record<string, unknown>;
+  order: string[]; // newest-first ids
+}
+
+function read(): CacheFile {
+  if (typeof localStorage === "undefined") return { trips: {}, order: [] };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { trips: {}, order: [] };
+    const parsed = JSON.parse(raw) as CacheFile;
+    if (!parsed?.trips || !Array.isArray(parsed.order)) return { trips: {}, order: [] };
+    return parsed;
+  } catch {
+    return { trips: {}, order: [] };
+  }
+}
+
+function write(file: CacheFile): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(file));
+  } catch (e) {
+    console.warn("offline trip cache write failed", e);
+  }
+}
+
+function serializeTrip(trip: Trip): unknown {
+  return { ...trip, version: trip.version.toString() };
+}
+
+function deserializeTrip(raw: unknown): Trip | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.id !== "string") return undefined;
+  return {
+    ...(o as unknown as Trip),
+    version: BigInt(typeof o.version === "string" || typeof o.version === "number" ? o.version : 0),
+  };
+}
+
+/** Persist a full trip for offline reopen. Keeps last MAX_TRIPS. */
+export function cacheTripOffline(trip: Trip): void {
+  const file = read();
+  file.trips[trip.id] = serializeTrip(trip);
+  file.order = [trip.id, ...file.order.filter((id) => id !== trip.id)].slice(0, MAX_TRIPS);
+  for (const id of Object.keys(file.trips)) {
+    if (!file.order.includes(id)) delete file.trips[id];
+  }
+  write(file);
+}
+
+export function getCachedTrip(id: string): Trip | undefined {
+  if (!id) return undefined;
+  return deserializeTrip(read().trips[id]);
+}
+
+export function listCachedTrips(): CachedTripSummary[] {
+  const file = read();
+  return file.order
+    .map((id) => deserializeTrip(file.trips[id]))
+    .filter((t): t is Trip => !!t)
+    .map((t) => ({
+      id: t.id,
+      title: t.title,
+      cityName: t.cityName,
+      dayCount: t.days?.length ?? 0,
+      updatedAt: t.updatedAt,
+    }));
+}
+
+export function clearOfflineTripCache(): void {
+  if (typeof localStorage === "undefined") return;
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/routes/offline.tsx
+++ b/src/routes/offline.tsx
@@ -1,40 +1,97 @@
-import { Component } from "solid-js";
+import { Component, For, Show, createSignal, onMount } from "solid-js";
+import { A } from "@solidjs/router";
 import { Button } from "@/ui/button";
-import { Wifi, RefreshCw } from "lucide-solid";
+import { Wifi, RefreshCw, Map, Trash2 } from "lucide-solid";
+import {
+  clearOfflineTripCache,
+  listCachedTrips,
+  type CachedTripSummary,
+} from "~/lib/trip-offline-cache";
 
 const OfflinePage: Component = () => {
+  const [cached, setCached] = createSignal<CachedTripSummary[]>([]);
+
+  const refresh = () => setCached(listCachedTrips());
+
+  onMount(refresh);
+
   const handleRetry = () => {
     window.location.reload();
   };
 
+  const handleClear = () => {
+    clearOfflineTripCache();
+    refresh();
+  };
+
   return (
-    <div class="min-h-screen flex items-center justify-center px-4 bg-background">
-      <div class="text-center max-w-md mx-auto px-6 glass-panel gradient-border rounded-2xl py-8 shadow-xl">
-        <div class="w-20 h-20 mx-auto mb-6 bg-primary rounded-full flex items-center justify-center shadow-lg ring-4 ring-border">
-          <Wifi class="w-10 h-10 text-primary-foreground" />
-        </div>
+    <div class="min-h-screen flex items-center justify-center px-4 bg-background py-12">
+      <div class="w-full max-w-md mx-auto px-6 glass-panel gradient-border rounded-2xl py-8 shadow-xl">
+        <div class="text-center">
+          <div class="w-20 h-20 mx-auto mb-6 bg-primary rounded-full flex items-center justify-center shadow-lg ring-4 ring-border">
+            <Wifi class="w-10 h-10 text-primary-foreground" />
+          </div>
 
-        <h1 class="text-2xl font-bold text-foreground mb-4">You're Offline</h1>
+          <h1 class="text-2xl font-bold text-foreground mb-4">You're Offline</h1>
 
-        <p class="text-muted-foreground mb-8 leading-relaxed">
-          It looks like you've lost your internet connection. Don't worry - you can still browse
-          your saved places and itineraries while offline.
-        </p>
+          <p class="text-muted-foreground mb-6 leading-relaxed">
+            Connection lost. Open a trip while online and it stays available here for later.
+          </p>
 
-        <div class="space-y-4">
-          <Button onClick={handleRetry} class="w-full py-3 font-semibold flex items-center justify-center gap-2">
+          <Button
+            onClick={handleRetry}
+            class="w-full py-3 font-semibold flex items-center justify-center gap-2 mb-6"
+          >
             <RefreshCw class="w-5 h-5" />
             Try Again
           </Button>
+        </div>
 
-          <div class="text-sm text-muted-foreground">
-            <p>You can still access:</p>
-            <ul class="mt-2 space-y-1">
-              <li>• Your saved favorites</li>
-              <li>• Downloaded itineraries</li>
-              <li>• Cached places and reviews</li>
-            </ul>
+        <div class="border-t border-border pt-5">
+          <div class="mb-3 flex items-center justify-between gap-2">
+            <h2 class="text-sm font-medium uppercase tracking-wide text-muted-foreground flex items-center gap-1.5">
+              <Map class="h-3.5 w-3.5" />
+              Cached trips
+            </h2>
+            <Show when={cached().length > 0}>
+              <button
+                type="button"
+                class="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+                onClick={handleClear}
+              >
+                <Trash2 class="h-3 w-3" />
+                Clear
+              </button>
+            </Show>
           </div>
+
+          <Show
+            when={cached().length > 0}
+            fallback={
+              <p class="text-sm text-muted-foreground">
+                No trips cached yet. Visit a trip page while online to save it for offline.
+              </p>
+            }
+          >
+            <ul class="space-y-2">
+              <For each={cached()}>
+                {(t) => (
+                  <li>
+                    <A
+                      href={`/trips/${t.id}`}
+                      class="block rounded-lg border border-border px-3 py-2.5 text-left transition hover:bg-muted/50"
+                    >
+                      <span class="font-medium text-foreground">{t.title}</span>
+                      <p class="text-xs text-muted-foreground">
+                        {t.cityName || "Trip"} · {t.dayCount} day
+                        {t.dayCount === 1 ? "" : "s"}
+                      </p>
+                    </A>
+                  </li>
+                )}
+              </For>
+            </ul>
+          </Show>
         </div>
       </div>
     </div>

--- a/src/routes/trips/[id].tsx
+++ b/src/routes/trips/[id].tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Show } from "solid-js";
+import { createSignal, For, Show, createEffect } from "solid-js";
 import { useParams } from "@solidjs/router";
 import {
   useTrip,
@@ -17,6 +17,7 @@ import { useUserSubscription } from "~/lib/api/billing";
 import { isProPlan } from "~/lib/subscription";
 import TripExportMenu from "~/components/trip/TripExportMenu";
 import WhyThisStop from "~/components/poi/WhyThisStop";
+import { cacheTripOffline } from "~/lib/trip-offline-cache";
 
 const minutesToHHMM = (m?: number) => {
   if (m == null) return "";
@@ -55,6 +56,11 @@ export default function TripEditor() {
 
   const trip = () => tripQuery.data as Trip | undefined;
   const version = () => trip()?.version ?? 0n;
+
+  createEffect(() => {
+    const t = trip();
+    if (t?.id) cacheTripOffline(t);
+  });
 
   const onMutationError = (err: unknown) => {
     const msg = err instanceof Error ? err.message : String(err);
@@ -132,7 +138,12 @@ export default function TripEditor() {
                 </p>
               </div>
               <div class="flex flex-wrap items-center gap-2">
-                <TripExportMenu tripId={params.id!} dayCount={t.days.length} isPro={isPro()} />
+                <TripExportMenu
+                  tripId={params.id!}
+                  dayCount={t.days.length}
+                  isPro={isPro()}
+                  trip={t}
+                />
                 <button
                   class="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90"
                   onClick={doShare}


### PR DESCRIPTION
## Summary
- Pro **Markdown** itinerary export from the trip editor (client-side; matches PRICING until proto `EXPORT_FORMAT_MARKDOWN`)
- **Offline lite:** cache last 12 opened trips in `localStorage`; `/offline` lists them with deep links
- `useTrip` uses `networkMode: offlineFirst` + cached placeholder

## Test plan
- [x] `tsc --noEmit`
- [x] `vitest` trip-markdown + why-this
- [ ] Pro user: trip editor → .md downloads with days/stops/why notes
- [ ] Free user: .md shows upgrade prompt
- [ ] Open a trip online → go offline / open `/offline` → see cached trip link


Made with [Cursor](https://cursor.com)