### PR TITLE
feat: server Markdown export + proto bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@buf/loci_loci-proto.bufbuild_es": "2.12.1-20260718080757-48b85c78a107.1",
+    "@buf/loci_loci-proto.bufbuild_es": "2.12.1-20260720203021-392270e1e2e5.1",
     "@bufbuild/protobuf": "^2.10.2",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-web": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@buf/loci_loci-proto.bufbuild_es':
-        specifier: 2.12.1-20260718080757-48b85c78a107.1
-        version: 2.12.1-20260718080757-48b85c78a107.1(@bufbuild/protobuf@2.12.1)
+        specifier: 2.12.1-20260720203021-392270e1e2e5.1
+        version: 2.12.1-20260720203021-392270e1e2e5.1(@bufbuild/protobuf@2.12.1)
       '@bufbuild/protobuf':
         specifier: ^2.10.2
         version: 2.12.1
@@ -676,8 +676,8 @@ packages:
     peerDependencies:
       '@bufbuild/protobuf': ^2.12.1
 
-  '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260718080757-48b85c78a107.1':
-    resolution: {integrity: sha512-9DxlNWftRjMJ7jm0V0o6cW1bDF89k79ZAEINuJgSnLbTYpXX0bDWx+dSWIkOo9mGt9KTWByaQoYiA7jrX3v2pA==}
+  '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260720203021-392270e1e2e5.1':
+    resolution: {integrity: sha512-jzq0GP8N9vkpYMw7GrXG9t1ot8D1Q4KJwA485Qkea64FgMg7jnIsipnTGrXV/WfTQMPipuZWXM2Ohai8d3GjqQ==}
     peerDependencies:
       '@bufbuild/protobuf': ^2.12.1
 
@@ -6056,7 +6056,7 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 2.12.1
 
-  '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260718080757-48b85c78a107.1(@bufbuild/protobuf@2.12.1)':
+  '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260720203021-392270e1e2e5.1(@bufbuild/protobuf@2.12.1)':
     dependencies:
       '@buf/bufbuild_protovalidate.bufbuild_es': 2.12.1-20251209175733-2a1774d88802.1(@bufbuild/protobuf@2.12.1)
       '@buf/protocolbuffers_wellknowntypes.bufbuild_es': 2.12.1-20230331140314-f17e05fe4a76.1(@bufbuild/protobuf@2.12.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,4 @@ allowBuilds:
   sharp: false
   workerd: false
 minimumReleaseAgeExclude:
-  - '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260711223240-70152a17f3bd.1 || 2.12.1-20260717234410-076bdef9cb1c.1 || 2.12.1-20260718080757-48b85c78a107.1'
+  - '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260711223240-70152a17f3bd.1 || 2.12.1-20260717234410-076bdef9cb1c.1 || 2.12.1-20260718080757-48b85c78a107.1 || 2.12.1-20260720203021-392270e1e2e5.1'

--- a/src/components/trip/TripExportMenu.tsx
+++ b/src/components/trip/TripExportMenu.tsx
@@ -1,9 +1,10 @@
 import { createSignal, Show } from "solid-js";
 import { A } from "@solidjs/router";
 import { CalendarPlus, Crown, Download, FileText, Lock } from "lucide-solid";
-import { exportTripICS, exportTripPDF, type Trip } from "~/lib/api/trips";
+import { exportTripICS, exportTripPDF, exportTripMarkdown, type Trip } from "~/lib/api/trips";
 import { downloadTripMarkdown } from "~/lib/trip-markdown";
 import { showUpgradePrompt } from "~/lib/upgrade-prompt";
+import { handleEntitlementError } from "~/lib/entitlement-error";
 
 export interface TripExportMenuProps {
   tripId: string;
@@ -63,21 +64,29 @@ export default function TripExportMenu(props: TripExportMenuProps) {
     }
   };
 
-  const handleMarkdown = () => {
+  const handleMarkdown = async () => {
     if (!props.isPro) {
       showUpgradePrompt("entitlement", "Markdown itinerary export is included with Pro.");
       return;
     }
-    if (!props.trip) {
-      flash("Trip still loading — try again in a moment.");
-      return;
-    }
     setBusy("md");
     try {
-      downloadTripMarkdown(props.trip);
+      await exportTripMarkdown(props.tripId);
       flash("Markdown downloaded.");
     } catch (e) {
-      flash(e instanceof Error ? e.message : "Markdown export failed");
+      if (handleEntitlementError(e)) {
+        flash("Upgrade to Pro for Markdown export.");
+      } else if (props.trip) {
+        // Fallback if server/proto lag — still deliver .md from local trip.
+        try {
+          downloadTripMarkdown(props.trip);
+          flash("Markdown downloaded (local).");
+        } catch (inner) {
+          flash(inner instanceof Error ? inner.message : "Markdown export failed");
+        }
+      } else {
+        flash(e instanceof Error ? e.message : "Markdown export failed");
+      }
     } finally {
       setBusy(null);
     }
@@ -112,7 +121,7 @@ export default function TripExportMenu(props: TripExportMenuProps) {
         type="button"
         class="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-accent disabled:opacity-50"
         disabled={busy() !== null}
-        onClick={handleMarkdown}
+        onClick={() => void handleMarkdown()}
         title={props.isPro ? "Download Markdown" : "Pro: Markdown export"}
       >
         <Show when={props.isPro} fallback={<Lock class="h-4 w-4" />}>

--- a/src/lib/api/llm.ts
+++ b/src/lib/api/llm.ts
@@ -157,6 +157,8 @@ export const mapPoi = (poi: ProtoPOIDetailedInfo): POIDetailedInfo => {
       typeof poi.starRating === "string" ? parseFloat(poi.starRating) : poi.starRating || 0,
     distance: poi.distance || 0,
     description_poi: poi.descriptionPoi || "",
+    recommendation_rationale: poi.recommendationRationale || "",
+    uncertainty_score: poi.uncertaintyScore,
     created_at:
       poi.createdAt && typeof (poi.createdAt as any).toDate === "function"
         ? (poi.createdAt as any).toDate().toISOString()

--- a/src/lib/api/trips.ts
+++ b/src/lib/api/trips.ts
@@ -262,15 +262,31 @@ export const exportTripICS = async (tripId: string) => exportTrip(tripId, Export
 /** Export trip as PDF (Pro-gated on server for multi-day; client soft-gates UX). */
 export const exportTripPDF = async (tripId: string) => exportTrip(tripId, ExportFormat.PDF);
 
+/** Export trip as Markdown (Pro-only on server). */
+export const exportTripMarkdown = async (tripId: string) =>
+  exportTrip(tripId, ExportFormat.MARKDOWN);
+
 async function exportTrip(tripId: string, format: ExportFormat) {
   const res = await tripClient.exportTrip(create(ExportTripRequestSchema, { tripId, format }));
   const blob = new Blob([res.data as unknown as BlobPart], {
-    type: res.contentType || (format === ExportFormat.PDF ? "application/pdf" : "text/calendar"),
+    type:
+      res.contentType ||
+      (format === ExportFormat.PDF
+        ? "application/pdf"
+        : format === ExportFormat.MARKDOWN
+          ? "text/markdown;charset=utf-8"
+          : "text/calendar"),
   });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = res.filename || (format === ExportFormat.PDF ? "trip.pdf" : "trip.ics");
+  a.download =
+    res.filename ||
+    (format === ExportFormat.PDF
+      ? "trip.pdf"
+      : format === ExportFormat.MARKDOWN
+        ? "trip.md"
+        : "trip.ics");
   document.body.appendChild(a);
   a.click();
   a.remove();


### PR DESCRIPTION
## Summary
- Bump `@buf/loci_loci-proto` to BSR commit with `EXPORT_FORMAT_MARKDOWN` + `recommendationRationale`
- Trip editor `.md` button calls `ExportTrip` (Pro-gated server-side); local renderer is fallback
- `mapPoi` passes through recommendation rationale for Why-this chips

## Test plan
- [x] `tsc --noEmit`
- [x] vitest trip-markdown / why-this
- [ ] Pro: download `.md` hits API and file matches trip
- [ ] Free: upgrade prompt / entitlement error


Made with [Cursor](https://cursor.com)