### PR TITLE
feat: EntitlementsBadge via GetEntitlements

### DIFF
--- a/src/components/EntitlementsBadge.tsx
+++ b/src/components/EntitlementsBadge.tsx
@@ -1,38 +1,34 @@
 import { Show, createMemo } from "solid-js";
 import { A } from "@solidjs/router";
-import { useLists } from "~/lib/api/lists";
-import { useFavoritesList } from "~/lib/api/favorites";
-import { useUserSubscription } from "~/lib/api/billing";
+import { useEntitlements } from "~/lib/api/entitlements";
 import { isProPlan } from "~/lib/subscription";
 
-/** Free-tier caps — keep in sync with server subscription/entitlements.go + PRICING.md */
-export const FREE_MAX_LISTS = 5;
-export const FREE_MAX_PLACES = 50;
-
 /**
- * Shows free-tier list/place usage (e.g. Lists 2/5 · Saves 12/50).
- * Hidden for Pro or when unauthenticated queries return empty.
+ * Shows free-tier list/place usage from EntitlementService.
+ * Saves = list items + favorites (server-authoritative).
  */
 export default function EntitlementsBadge() {
-  const subscription = useUserSubscription();
-  const lists = useLists();
-  const favorites = useFavoritesList();
+  const entitlements = useEntitlements();
 
-  const isPro = () => isProPlan(subscription.data?.plan);
+  const data = createMemo(() => entitlements.data);
+  const isPro = () => isProPlan(data()?.plan);
 
-  const listCount = createMemo(() => (lists.data ?? []).length);
-  const placeCount = createMemo(() => {
-    const favs = favorites.data?.items?.length ?? 0;
-    // List item totals aren't in GetLists payload cheaply — favorites alone is
-    // the visible "saves" signal until EntitlementService lands.
-    return favs;
-  });
+  const listCount = () => data()?.listsUsed ?? 0;
+  const listLimit = () => data()?.listsLimit ?? 5;
+  const placeCount = () => data()?.placesSaved ?? 0;
+  const placeLimit = () => data()?.placesLimit ?? 50;
 
-  const nearListLimit = () => !isPro() && listCount() >= FREE_MAX_LISTS - 1;
-  const nearPlaceLimit = () => !isPro() && placeCount() >= FREE_MAX_PLACES - 5;
+  const nearListLimit = () => {
+    const lim = listLimit();
+    return !isPro() && lim > 0 && listCount() >= lim - 1;
+  };
+  const nearPlaceLimit = () => {
+    const lim = placeLimit();
+    return !isPro() && lim > 0 && placeCount() >= lim - 5;
+  };
 
   return (
-    <Show when={!isPro() && (listCount() > 0 || placeCount() > 0)}>
+    <Show when={data() && !isPro() && (listCount() > 0 || placeCount() > 0)}>
       <A
         href="/pricing"
         class={`hidden sm:inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors hover:border-primary/40 ${
@@ -43,11 +39,11 @@ export default function EntitlementsBadge() {
         title="Free plan usage — upgrade for unlimited saves"
       >
         <span>
-          Lists {listCount()}/{FREE_MAX_LISTS}
+          Lists {listCount()}/{listLimit()}
         </span>
         <span class="opacity-40">·</span>
         <span>
-          Saves {placeCount()}/{FREE_MAX_PLACES}
+          Saves {placeCount()}/{placeLimit()}
         </span>
       </A>
     </Show>

--- a/src/lib/api/entitlements.ts
+++ b/src/lib/api/entitlements.ts
@@ -1,0 +1,61 @@
+// Freemium entitlement counters via EntitlementService.GetEntitlements.
+// Uses Connect JSON over the shared transport base URL until the BSR package
+// ships EntitlementService (then switch to createClient like billing.ts).
+import { useQuery } from "@tanstack/solid-query";
+import { getAuthToken } from "../auth/tokens";
+
+const API_BASE_URL = import.meta.env.VITE_CONNECT_BASE_URL || "http://localhost:8000";
+
+export interface Entitlements {
+  plan: string;
+  listsUsed: number;
+  listsLimit: number; // -1 = unlimited
+  placesSaved: number;
+  placesLimit: number; // -1 = unlimited
+  advancedFilters: boolean;
+  exportFull: boolean;
+}
+
+function mapEntitlements(raw: Record<string, unknown>): Entitlements {
+  return {
+    plan: String(raw.plan ?? "free"),
+    listsUsed: Number(raw.listsUsed ?? 0),
+    listsLimit: Number(raw.listsLimit ?? 5),
+    placesSaved: Number(raw.placesSaved ?? 0),
+    placesLimit: Number(raw.placesLimit ?? 50),
+    advancedFilters: Boolean(raw.advancedFilters),
+    exportFull: Boolean(raw.exportFull),
+  };
+}
+
+export async function fetchEntitlements(): Promise<Entitlements | null> {
+  const token = getAuthToken();
+  if (!token) return null;
+
+  const res = await fetch(
+    `${API_BASE_URL}/loci.entitlement.v1.EntitlementService/GetEntitlements`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: "{}",
+    },
+  );
+  if (res.status === 401 || res.status === 403) return null;
+  if (!res.ok) {
+    throw new Error(`GetEntitlements failed: ${res.status}`);
+  }
+  const data = (await res.json()) as Record<string, unknown>;
+  return mapEntitlements(data);
+}
+
+export function useEntitlements() {
+  return useQuery(() => ({
+    queryKey: ["entitlements"],
+    queryFn: fetchEntitlements,
+    staleTime: 60_000,
+    retry: 1,
+  }));
+}


### PR DESCRIPTION
## Summary
- `useEntitlements` → `EntitlementService/GetEntitlements`
- Badge Shows Lists X/Y · Saves A/B where Saves = list items + favorites
- Connect JSON client until BSR packages EntitlementService (then swap to createClient)

Depends on server [PR #8](https://github.com/FACorreiaa/loci-connect-api/pull/8) + proto [PR #3](https://github.com/FACorreiaa/loci-connect-proto/pull/3).

## Test plan
- [x] `tsc --noEmit`
- [ ] Free user: badge matches DB list+fav counts
- [ ] Pro: badge hidden


Made with [Cursor](https://cursor.com)