### PR TITLE
Build the Loci travel discovery experience

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,13 +40,13 @@ Recommendation cards should communicate:
 
 ## Motion vocabulary
 
-| Token | Use | Default |
-|---|---|---|
-| `resultArrive` | Card/list stagger | 400ms, ease-enter |
-| `selectionSettle` | Map/list selection | 250ms, ease-settle |
-| `routeDraw` | Route line appear | 800ms opacity |
-| `sheetPresent` | Overlays, split toggles | 300ms |
-| `press` | Buttons, tappable cards | scale 0.98 |
+| Token             | Use                     | Default            |
+| ----------------- | ----------------------- | ------------------ |
+| `resultArrive`    | Card/list stagger       | 400ms, ease-enter  |
+| `selectionSettle` | Map/list selection      | 250ms, ease-settle |
+| `routeDraw`       | Route line appear       | 800ms opacity      |
+| `sheetPresent`    | Overlays, split toggles | 300ms              |
+| `press`           | Buttons, tappable cards | scale 0.98         |
 
 Respect `prefers-reduced-motion`: disable stagger, route draw, and scale press.
 
@@ -54,12 +54,12 @@ CSS: `--motion-*`, `--ease-*` in `motion-tokens.css`; stagger in `animations.css
 
 ## Surface materials
 
-| Class | When |
-|---|---|
-| `.loci-card` | Default content container (flat + border) |
-| `.loci-card-interactive` | Tappable POI/trip/list rows |
-| `.island-panel` | **One** floating overlay (nav sheet, map toggle, chat widget)—not stacked blur |
-| `.trust-chip` | Why-this-stop / rationale |
+| Class                    | When                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `.loci-card`             | Default content container (flat + border)                                      |
+| `.loci-card-interactive` | Tappable POI/trip/list rows                                                    |
+| `.island-panel`          | **One** floating overlay (nav sheet, map toggle, chat widget)—not stacked blur |
+| `.trust-chip`            | Why-this-stop / rationale                                                      |
 
 Avoid `.glass-panel` + `backdrop-blur-xl` nesting. Legacy `.glass-panel` maps to flat card styling in base.css.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,90 @@
+# Loci web design system
+
+Loci is a modern field guide for travel recommendations and editable adventures. The product should feel observant, grounded, and useful outdoors—not like a generic AI dashboard.
+
+Quality bar: **Flighty-class polish** (fluid motion, map as a living surface, calm density, native-feeling micro-interactions) expressed through **Loci's own theme**—not flight-tracker UI, not purple AI chrome, not Expo defaults.
+
+## Visual language
+
+- Warm parchment backgrounds, deep forest ink, muted sage support, and terracotta for actions and map marks.
+- `Fraunces` for destination and journey headlines, `DM Sans` for interface copy, and `Space Mono` for coordinates, route numbers, evidence, and status labels.
+- Cartographic contours, route lines, stamps, and field-note labels are the recurring motifs.
+- Surfaces are mostly flat with a visible one-pixel border. Use shadows only to establish navigation, overlays, or hover lift.
+- The single brand system is `loci`; light, dark, and system are appearance modes rather than separate design themes.
+
+## Product hierarchy
+
+The primary journeys are Discover, Nearby, Trips, and Ask Loci. Favorites, recents, lists, travel profiles, contribution, and settings support those journeys and live in the account field kit.
+
+Recommendation cards should communicate:
+
+1. what the place is;
+2. why it fits;
+3. how current or trustworthy the facts are;
+4. the next useful action—keep, add to a trip, replace, or dismiss.
+
+## Map language
+
+- Basemap follows light/dark appearance; markers and routes carry brand color (forest → sage → terracotta day scale).
+- Clusters use forest ink, not generic blue.
+- Popups are field notes: title, category, rating/time/budget, optional dog-friendly label—no emoji badges.
+- Route lines draw in with a short opacity settle; selection enlarges the mark and flies the camera.
+- On spatial journeys (Nearby, itinerary, trip editor), map can be **hero**—full bleed or dominant panel—not only an inset utility.
+
+## Chat composition
+
+- User messages: compact primary bubbles.
+- Assistant text: flat card bubble; **structured results live outside the bubble** in `.loci-card` / editorial stream—not nested glass stacks.
+- Floating chat and full `/chat` share the same bubble, composer, and embed materials.
+- Streaming: quiet phase rail + progressive card arrival; no emoji-as-navigation in quick prompts.
+
+## Motion vocabulary
+
+| Token | Use | Default |
+|---|---|---|
+| `resultArrive` | Card/list stagger | 400ms, ease-enter |
+| `selectionSettle` | Map/list selection | 250ms, ease-settle |
+| `routeDraw` | Route line appear | 800ms opacity |
+| `sheetPresent` | Overlays, split toggles | 300ms |
+| `press` | Buttons, tappable cards | scale 0.98 |
+
+Respect `prefers-reduced-motion`: disable stagger, route draw, and scale press.
+
+CSS: `--motion-*`, `--ease-*` in `motion-tokens.css`; stagger in `animations.css`.
+
+## Surface materials
+
+| Class | When |
+|---|---|
+| `.loci-card` | Default content container (flat + border) |
+| `.loci-card-interactive` | Tappable POI/trip/list rows |
+| `.island-panel` | **One** floating overlay (nav sheet, map toggle, chat widget)—not stacked blur |
+| `.trust-chip` | Why-this-stop / rationale |
+
+Avoid `.glass-panel` + `backdrop-blur-xl` nesting. Legacy `.glass-panel` maps to flat card styling in base.css.
+
+## Interaction rules
+
+- Prefer direct manipulation and progressive updates. Streaming results should appear as they arrive.
+- Every interactive control needs a visible focus state and a minimum 44px mobile target.
+- Motion is limited to route drawing, result arrival, and small state transitions; respect reduced-motion preferences.
+- Avoid decorative gradients, excessive pills, nested card stacks, emoji-as-navigation, rainbow map day dots, hardcoded blue SaaS chrome, and fake metrics.
+
+## Anti-patterns (Flighty-quality / Loci-theme)
+
+- Purple-on-white or indigo AI dashboard themes
+- Mapbox default blue clusters and rainbow itinerary pins
+- Emoji in nav, quick prompts, or map popups
+- Dual chat quality (rich `/chat` vs plain floating widget)
+- Nested `backdrop-blur` panels inside chat bubbles
+
+## Trust and learning
+
+- Explain recommendation rationale near the recommendation (`WhyThisStop` / `.trust-chip`).
+- Keep private personalization and aggregate quality contribution as separate controls.
+- Make learned taste traits inspectable and resettable.
+- Community place facts show confidence, contributor count, verification date, and expiry.
+
+## Native parity
+
+Implementation-ready SwiftUI + Jetpack Compose guidance: [docs/NATIVE_DESIGN.md](docs/NATIVE_DESIGN.md).

--- a/docs/NATIVE_DESIGN.md
+++ b/docs/NATIVE_DESIGN.md
@@ -1,0 +1,250 @@
+# Loci native design (SwiftUI + Jetpack Compose)
+
+Implementation-ready parity guide for iOS and Android. Web SSOT: [DESIGN.md](../DESIGN.md).
+
+Quality bar: **Flighty-class** motion and density, **Loci field-guide** theme (parchment / forest / sage / terracotta). Not flight-tracker UI, not purple AI chrome, not Expo defaults.
+
+---
+
+## 1. Color tokens
+
+HSL source matches web `themes.css`. Use sRGB in native.
+
+### Light
+
+| Token | HSL | sRGB (approx) | Use |
+|---|---|---|---|
+| `background` | 43 38% 94% | `#F5F0E6` | Screen base |
+| `foreground` | 157 28% 14% | `#1A2E26` | Primary text |
+| `card` | 42 44% 98% | `#FDFBF7` | Surfaces |
+| `primary` | 157 35% 20% | `#214D3C` | Actions, map clusters |
+| `secondary` | 91 18% 84% | `#D8E0D0` | Chips, inactive tabs |
+| `muted` | 40 23% 88% | `#E8E2D6` | Subtle fills |
+| `mutedForeground` | 151 10% 39% | `#5A6B62` | Secondary text |
+| `accent` | 16 52% 48% | `#C76B4A` | Map marks, CTAs |
+| `border` | 42 18% 75% | `#CFC5B5` | 1px edges |
+| `destructive` | 2 58% 44% | `#B33A32` | Errors |
+
+### Dark
+
+| Token | HSL | sRGB (approx) |
+|---|---|---|
+| `background` | 157 22% 8% | `#101A16` |
+| `foreground` | 42 30% 91% | `#EDE8DC` |
+| `card` | 157 20% 11% | `#162019` |
+| `primary` | 88 21% 68% | `#A8B896` |
+| `accent` | 20 60% 61% | `#D4845C` |
+| `border` | 154 12% 25% | `#384840` |
+
+### Map day palette (itinerary pins + routes)
+
+Same order as web `LOCI_DAY_COLORS` in `src/lib/theme-colors.ts`:
+
+`#294d3c`, `#5a7a55`, `#c76b4a`, `#8a6e2f`, `#3d5a4a`, `#a85a3a`, `#6b8f71`, `#d4845c`
+
+Cluster color: `#294d3c`. Ungrouped: `#6b7c72`.
+
+---
+
+## 2. Typography
+
+| Role | Web | iOS | Android |
+|---|---|---|---|
+| Destination headlines | Fraunces | `Font.custom("Fraunces", …)` or Fraunces via Google Fonts | `FontFamily(Font(R.font.fraunces))` |
+| UI body | DM Sans | DM Sans | `FontFamily(Font(R.font.dm_sans))` |
+| Coords / seq / status | Space Mono | Space Mono | `FontFamily(Font(R.font.space_mono))` |
+
+### Scale (iOS Dynamic Type / Compose `sp`)
+
+| Style | Size | Weight | Font |
+|---|---|---|---|
+| `display` | 34–40 | Semibold | Fraunces |
+| `title` | 22–28 | Semibold | Fraunces |
+| `headline` | 17–20 | Medium | DM Sans |
+| `body` | 15–17 | Regular | DM Sans |
+| `caption` | 12–13 | Regular | DM Sans |
+| `coord` | 10–11 | Medium | Space Mono, uppercase tracking |
+
+---
+
+## 3. Spacing & radius
+
+| Token | Value |
+|---|---|
+| `radius` | 12.8pt / 12.8dp (`0.8rem`) |
+| `radiusHero` | 14.4pt |
+| Min tap target | 44×44 |
+| Screen padding | 16 mobile / 24 tablet |
+| Card padding | 16–20 |
+
+Elevation: **flat + 1px border**. Shadow only for floating island panels and nav.
+
+---
+
+## 4. Motion
+
+| Name | Duration | Curve | Use |
+|---|---|---|---|
+| `resultArrive` | 400ms | ease-out (0.16, 1, 0.3, 1) | List/card stagger |
+| `selectionSettle` | 250ms | ease-out (0.22, 1, 0.36, 1) | Map↔list selection |
+| `routeDraw` | 800ms | linear opacity | Route line appear |
+| `sheetPresent` | 300ms | spring (iOS) / `FastOutSlowInEasing` | Bottom sheet, chat |
+| `press` | 150ms | scale 0.98 | Buttons, cards |
+
+**Reduce Motion:** disable stagger, route draw, scale press; keep opacity fades ≤200ms.
+
+### iOS
+
+- SwiftUI: `.animation(.spring(response: 0.35, dampingFraction: 0.86), value:)` for selection
+- UIKit haptics: `.light` on pin select, `.medium` on add-to-trip
+
+### Android
+
+- Compose: `animateFloatAsState`, `AnimatedVisibility`, `Modifier.graphicsLayer { scaleX/scaleY }`
+- `HapticFeedbackConstants.KEYBOARD_TAP` on selection
+
+---
+
+## 5. Component catalog
+
+### Tab bar / primary nav
+
+- Four journeys: Discover, Nearby, Trips, Ask Loci
+- Active: `secondary` fill + `foreground` label
+- iOS: `TabView` or custom tab bar; Android: `NavigationBar` (Material 3, **not** default purple — theme `LociTheme`)
+
+### Field card (`LociCard`)
+
+- Background `card`, border `border`, radius `radius`
+- Interactive: border darkens to `primary/35` on press; no nested shadows
+
+### Stop card
+
+- Seq number in Space Mono circle (terracotta border)
+- Title Fraunces; category DM Sans caption
+- Trust chip below description
+
+### Chat bubble vs embed
+
+- **User:** compact `primary` bubble
+- **Assistant text:** flat `card` bubble
+- **Structured results:** full-width `LociCard` **outside** bubble (itinerary stream, POI lists)
+
+### Composer
+
+- Flat top border; textarea + primary send button (44dp)
+- Stop button replaces send while streaming
+
+### Map pin + route
+
+- Circle marker, white stroke, day color fill, Space Mono label
+- Selected: stroke 4pt, radius +4
+- Route: dashed line, day color, `routeDraw` opacity
+
+### Trust chip
+
+- Border `primary/20`, fill `primary/5`, Sparkles icon, “Why this:” label
+
+### Empty / error
+
+- Centered icon (Lucide → SF Symbol / Material icon map)
+- Fraunces title + DM Sans subtitle; single primary CTA
+
+### Upgrade prompt
+
+- Flat card, accent border, no gradient hero
+
+---
+
+## 6. Screen map
+
+| Screen | Composition |
+|---|---|
+| **Discover** | Search hero + category grid + result cards (list-first); optional map later |
+| **Nearby** | **Map hero** default; bottom/side sheet for POI list |
+| **Trips** | Route cards grid; editor = day/stop list (map v2 when stop coords available) |
+| **Ask Loci** | Full-screen chat; structured embeds as cards |
+| **Settings** | Field kit sections in `LociCard` stacks |
+
+Floating web chat FAB → native **bottom sheet** or dedicated tab (prefer tab for parity with primary nav).
+
+---
+
+## 7. Libraries to add
+
+### iOS (SwiftUI)
+
+| Package | Purpose |
+|---|---|
+| Mapbox Maps SDK (`mapbox-maps-ios`) | Branded basemap + GeoJSON layers (matches web) |
+| — or MapKit | Lighter v1 if Mapbox key sharing is awkward |
+| — | Embed Fraunces, DM Sans, Space Mono (Google Fonts or bundled) |
+| — | SF Symbols mapped from Lucide semantics (see parity table) |
+
+Architecture: `NavigationStack`, `.sheet` for detail, `@Observable` view models, Connect Swift client for API.
+
+### Android (Jetpack Compose)
+
+| Dependency | Purpose |
+|---|---|
+| `com.mapbox.maps:android` | Map parity with web |
+| Material 3 | Themed with Loci colors (`ColorScheme` override — no dynamic purple) |
+| Navigation Compose | Primary journeys |
+| Compose Animation | Motion tokens |
+
+---
+
+## 8. Icon parity (Lucide → native)
+
+| Lucide | SF Symbol | Material |
+|---|---|---|
+| Compass | `safari` | `Explore` |
+| MapPin | `mappin.and.ellipse` | `Place` |
+| Map | `map` | `Map` |
+| MessageCircle | `bubble.left.and.bubble.right` | `Chat` |
+| Utensils | `fork.knife` | `Restaurant` |
+| Bed | `bed.double` | `Hotel` |
+| Sparkles | `sparkles` | `AutoAwesome` |
+| Heart | `heart` | `Favorite` |
+| Navigation | `location.north` | `Navigation` |
+
+---
+
+## 9. Parity checklist
+
+| Web surface | iOS | Android | Notes |
+|---|---|---|---|
+| Design tokens (`themes.css`) | `LociColors.swift` | `LociTheme.kt` | §1 |
+| Motion tokens | `LociMotion.swift` | `LociMotion.kt` | §4 |
+| `Map.tsx` pins/routes | Mapbox layers | Mapbox layers | Day colors §1 |
+| `SplitView` | Map + sheet | Map + `BottomSheetScaffold` | Map default Nearby |
+| `ChatMessage` + embeds | Bubble + card stack | Same | No nested blur |
+| `ItineraryStreamView` | Stop list + phase rail | Same | Reuse stop card |
+| `WhyThisStop` | Trust chip | Trust chip | |
+| `Discover` cards | Field card + stagger | Same | |
+| `Nav` / tab bar | TabView | NavigationBar | Four journeys |
+| Auth | `SignIn` layout | Same | Flat inputs |
+| Settings field kit | Section cards | Same | |
+| PWA / FAB chat | **Sheet or tab** | **Sheet or tab** | No web FAB clone |
+
+---
+
+## 10. Out of scope (native v1)
+
+- SolidStart / PWA install chrome
+- Web-only `FloatingChat` FAB shape (use platform sheet)
+- Flighty flight-specific UI (gates, delays, airplane motifs)
+- Expo / React Native shared UI layer
+
+---
+
+## 11. Implementation order
+
+1. Color + type theme objects
+2. `LociCard`, trust chip, tab bar
+3. Map pins + list sheet (Nearby)
+4. Chat bubbles + itinerary embeds
+5. Discover + Trips lists
+6. Settings + auth
+
+Validate against web screenshots on each milestone; run Reduce Motion QA on iOS Simulator + Android emulator.

--- a/docs/NATIVE_DESIGN.md
+++ b/docs/NATIVE_DESIGN.md
@@ -12,29 +12,29 @@ HSL source matches web `themes.css`. Use sRGB in native.
 
 ### Light
 
-| Token | HSL | sRGB (approx) | Use |
-|---|---|---|---|
-| `background` | 43 38% 94% | `#F5F0E6` | Screen base |
-| `foreground` | 157 28% 14% | `#1A2E26` | Primary text |
-| `card` | 42 44% 98% | `#FDFBF7` | Surfaces |
-| `primary` | 157 35% 20% | `#214D3C` | Actions, map clusters |
-| `secondary` | 91 18% 84% | `#D8E0D0` | Chips, inactive tabs |
-| `muted` | 40 23% 88% | `#E8E2D6` | Subtle fills |
-| `mutedForeground` | 151 10% 39% | `#5A6B62` | Secondary text |
-| `accent` | 16 52% 48% | `#C76B4A` | Map marks, CTAs |
-| `border` | 42 18% 75% | `#CFC5B5` | 1px edges |
-| `destructive` | 2 58% 44% | `#B33A32` | Errors |
+| Token             | HSL         | sRGB (approx) | Use                   |
+| ----------------- | ----------- | ------------- | --------------------- |
+| `background`      | 43 38% 94%  | `#F5F0E6`     | Screen base           |
+| `foreground`      | 157 28% 14% | `#1A2E26`     | Primary text          |
+| `card`            | 42 44% 98%  | `#FDFBF7`     | Surfaces              |
+| `primary`         | 157 35% 20% | `#214D3C`     | Actions, map clusters |
+| `secondary`       | 91 18% 84%  | `#D8E0D0`     | Chips, inactive tabs  |
+| `muted`           | 40 23% 88%  | `#E8E2D6`     | Subtle fills          |
+| `mutedForeground` | 151 10% 39% | `#5A6B62`     | Secondary text        |
+| `accent`          | 16 52% 48%  | `#C76B4A`     | Map marks, CTAs       |
+| `border`          | 42 18% 75%  | `#CFC5B5`     | 1px edges             |
+| `destructive`     | 2 58% 44%   | `#B33A32`     | Errors                |
 
 ### Dark
 
-| Token | HSL | sRGB (approx) |
-|---|---|---|
-| `background` | 157 22% 8% | `#101A16` |
-| `foreground` | 42 30% 91% | `#EDE8DC` |
-| `card` | 157 20% 11% | `#162019` |
-| `primary` | 88 21% 68% | `#A8B896` |
-| `accent` | 20 60% 61% | `#D4845C` |
-| `border` | 154 12% 25% | `#384840` |
+| Token        | HSL         | sRGB (approx) |
+| ------------ | ----------- | ------------- |
+| `background` | 157 22% 8%  | `#101A16`     |
+| `foreground` | 42 30% 91%  | `#EDE8DC`     |
+| `card`       | 157 20% 11% | `#162019`     |
+| `primary`    | 88 21% 68%  | `#A8B896`     |
+| `accent`     | 20 60% 61%  | `#D4845C`     |
+| `border`     | 154 12% 25% | `#384840`     |
 
 ### Map day palette (itinerary pins + routes)
 
@@ -48,34 +48,34 @@ Cluster color: `#294d3c`. Ungrouped: `#6b7c72`.
 
 ## 2. Typography
 
-| Role | Web | iOS | Android |
-|---|---|---|---|
-| Destination headlines | Fraunces | `Font.custom("Fraunces", …)` or Fraunces via Google Fonts | `FontFamily(Font(R.font.fraunces))` |
-| UI body | DM Sans | DM Sans | `FontFamily(Font(R.font.dm_sans))` |
-| Coords / seq / status | Space Mono | Space Mono | `FontFamily(Font(R.font.space_mono))` |
+| Role                  | Web        | iOS                                                       | Android                               |
+| --------------------- | ---------- | --------------------------------------------------------- | ------------------------------------- |
+| Destination headlines | Fraunces   | `Font.custom("Fraunces", …)` or Fraunces via Google Fonts | `FontFamily(Font(R.font.fraunces))`   |
+| UI body               | DM Sans    | DM Sans                                                   | `FontFamily(Font(R.font.dm_sans))`    |
+| Coords / seq / status | Space Mono | Space Mono                                                | `FontFamily(Font(R.font.space_mono))` |
 
 ### Scale (iOS Dynamic Type / Compose `sp`)
 
-| Style | Size | Weight | Font |
-|---|---|---|---|
-| `display` | 34–40 | Semibold | Fraunces |
-| `title` | 22–28 | Semibold | Fraunces |
-| `headline` | 17–20 | Medium | DM Sans |
-| `body` | 15–17 | Regular | DM Sans |
-| `caption` | 12–13 | Regular | DM Sans |
-| `coord` | 10–11 | Medium | Space Mono, uppercase tracking |
+| Style      | Size  | Weight   | Font                           |
+| ---------- | ----- | -------- | ------------------------------ |
+| `display`  | 34–40 | Semibold | Fraunces                       |
+| `title`    | 22–28 | Semibold | Fraunces                       |
+| `headline` | 17–20 | Medium   | DM Sans                        |
+| `body`     | 15–17 | Regular  | DM Sans                        |
+| `caption`  | 12–13 | Regular  | DM Sans                        |
+| `coord`    | 10–11 | Medium   | Space Mono, uppercase tracking |
 
 ---
 
 ## 3. Spacing & radius
 
-| Token | Value |
-|---|---|
-| `radius` | 12.8pt / 12.8dp (`0.8rem`) |
-| `radiusHero` | 14.4pt |
-| Min tap target | 44×44 |
-| Screen padding | 16 mobile / 24 tablet |
-| Card padding | 16–20 |
+| Token          | Value                      |
+| -------------- | -------------------------- |
+| `radius`       | 12.8pt / 12.8dp (`0.8rem`) |
+| `radiusHero`   | 14.4pt                     |
+| Min tap target | 44×44                      |
+| Screen padding | 16 mobile / 24 tablet      |
+| Card padding   | 16–20                      |
 
 Elevation: **flat + 1px border**. Shadow only for floating island panels and nav.
 
@@ -83,13 +83,13 @@ Elevation: **flat + 1px border**. Shadow only for floating island panels and nav
 
 ## 4. Motion
 
-| Name | Duration | Curve | Use |
-|---|---|---|---|
-| `resultArrive` | 400ms | ease-out (0.16, 1, 0.3, 1) | List/card stagger |
-| `selectionSettle` | 250ms | ease-out (0.22, 1, 0.36, 1) | Map↔list selection |
-| `routeDraw` | 800ms | linear opacity | Route line appear |
-| `sheetPresent` | 300ms | spring (iOS) / `FastOutSlowInEasing` | Bottom sheet, chat |
-| `press` | 150ms | scale 0.98 | Buttons, cards |
+| Name              | Duration | Curve                                | Use                |
+| ----------------- | -------- | ------------------------------------ | ------------------ |
+| `resultArrive`    | 400ms    | ease-out (0.16, 1, 0.3, 1)           | List/card stagger  |
+| `selectionSettle` | 250ms    | ease-out (0.22, 1, 0.36, 1)          | Map↔list selection |
+| `routeDraw`       | 800ms    | linear opacity                       | Route line appear  |
+| `sheetPresent`    | 300ms    | spring (iOS) / `FastOutSlowInEasing` | Bottom sheet, chat |
+| `press`           | 150ms    | scale 0.98                           | Buttons, cards     |
 
 **Reduce Motion:** disable stagger, route draw, scale press; keep opacity fades ≤200ms.
 
@@ -158,13 +158,13 @@ Elevation: **flat + 1px border**. Shadow only for floating island panels and nav
 
 ## 6. Screen map
 
-| Screen | Composition |
-|---|---|
-| **Discover** | Search hero + category grid + result cards (list-first); optional map later |
-| **Nearby** | **Map hero** default; bottom/side sheet for POI list |
-| **Trips** | Route cards grid; editor = day/stop list (map v2 when stop coords available) |
-| **Ask Loci** | Full-screen chat; structured embeds as cards |
-| **Settings** | Field kit sections in `LociCard` stacks |
+| Screen       | Composition                                                                  |
+| ------------ | ---------------------------------------------------------------------------- |
+| **Discover** | Search hero + category grid + result cards (list-first); optional map later  |
+| **Nearby**   | **Map hero** default; bottom/side sheet for POI list                         |
+| **Trips**    | Route cards grid; editor = day/stop list (map v2 when stop coords available) |
+| **Ask Loci** | Full-screen chat; structured embeds as cards                                 |
+| **Settings** | Field kit sections in `LociCard` stacks                                      |
 
 Floating web chat FAB → native **bottom sheet** or dedicated tab (prefer tab for parity with primary nav).
 
@@ -174,58 +174,58 @@ Floating web chat FAB → native **bottom sheet** or dedicated tab (prefer tab f
 
 ### iOS (SwiftUI)
 
-| Package | Purpose |
-|---|---|
-| Mapbox Maps SDK (`mapbox-maps-ios`) | Branded basemap + GeoJSON layers (matches web) |
-| — or MapKit | Lighter v1 if Mapbox key sharing is awkward |
-| — | Embed Fraunces, DM Sans, Space Mono (Google Fonts or bundled) |
-| — | SF Symbols mapped from Lucide semantics (see parity table) |
+| Package                             | Purpose                                                       |
+| ----------------------------------- | ------------------------------------------------------------- |
+| Mapbox Maps SDK (`mapbox-maps-ios`) | Branded basemap + GeoJSON layers (matches web)                |
+| — or MapKit                         | Lighter v1 if Mapbox key sharing is awkward                   |
+| —                                   | Embed Fraunces, DM Sans, Space Mono (Google Fonts or bundled) |
+| —                                   | SF Symbols mapped from Lucide semantics (see parity table)    |
 
 Architecture: `NavigationStack`, `.sheet` for detail, `@Observable` view models, Connect Swift client for API.
 
 ### Android (Jetpack Compose)
 
-| Dependency | Purpose |
-|---|---|
-| `com.mapbox.maps:android` | Map parity with web |
-| Material 3 | Themed with Loci colors (`ColorScheme` override — no dynamic purple) |
-| Navigation Compose | Primary journeys |
-| Compose Animation | Motion tokens |
+| Dependency                | Purpose                                                              |
+| ------------------------- | -------------------------------------------------------------------- |
+| `com.mapbox.maps:android` | Map parity with web                                                  |
+| Material 3                | Themed with Loci colors (`ColorScheme` override — no dynamic purple) |
+| Navigation Compose        | Primary journeys                                                     |
+| Compose Animation         | Motion tokens                                                        |
 
 ---
 
 ## 8. Icon parity (Lucide → native)
 
-| Lucide | SF Symbol | Material |
-|---|---|---|
-| Compass | `safari` | `Explore` |
-| MapPin | `mappin.and.ellipse` | `Place` |
-| Map | `map` | `Map` |
-| MessageCircle | `bubble.left.and.bubble.right` | `Chat` |
-| Utensils | `fork.knife` | `Restaurant` |
-| Bed | `bed.double` | `Hotel` |
-| Sparkles | `sparkles` | `AutoAwesome` |
-| Heart | `heart` | `Favorite` |
-| Navigation | `location.north` | `Navigation` |
+| Lucide        | SF Symbol                      | Material      |
+| ------------- | ------------------------------ | ------------- |
+| Compass       | `safari`                       | `Explore`     |
+| MapPin        | `mappin.and.ellipse`           | `Place`       |
+| Map           | `map`                          | `Map`         |
+| MessageCircle | `bubble.left.and.bubble.right` | `Chat`        |
+| Utensils      | `fork.knife`                   | `Restaurant`  |
+| Bed           | `bed.double`                   | `Hotel`       |
+| Sparkles      | `sparkles`                     | `AutoAwesome` |
+| Heart         | `heart`                        | `Favorite`    |
+| Navigation    | `location.north`               | `Navigation`  |
 
 ---
 
 ## 9. Parity checklist
 
-| Web surface | iOS | Android | Notes |
-|---|---|---|---|
-| Design tokens (`themes.css`) | `LociColors.swift` | `LociTheme.kt` | §1 |
-| Motion tokens | `LociMotion.swift` | `LociMotion.kt` | §4 |
-| `Map.tsx` pins/routes | Mapbox layers | Mapbox layers | Day colors §1 |
-| `SplitView` | Map + sheet | Map + `BottomSheetScaffold` | Map default Nearby |
-| `ChatMessage` + embeds | Bubble + card stack | Same | No nested blur |
-| `ItineraryStreamView` | Stop list + phase rail | Same | Reuse stop card |
-| `WhyThisStop` | Trust chip | Trust chip | |
-| `Discover` cards | Field card + stagger | Same | |
-| `Nav` / tab bar | TabView | NavigationBar | Four journeys |
-| Auth | `SignIn` layout | Same | Flat inputs |
-| Settings field kit | Section cards | Same | |
-| PWA / FAB chat | **Sheet or tab** | **Sheet or tab** | No web FAB clone |
+| Web surface                  | iOS                    | Android                     | Notes              |
+| ---------------------------- | ---------------------- | --------------------------- | ------------------ |
+| Design tokens (`themes.css`) | `LociColors.swift`     | `LociTheme.kt`              | §1                 |
+| Motion tokens                | `LociMotion.swift`     | `LociMotion.kt`             | §4                 |
+| `Map.tsx` pins/routes        | Mapbox layers          | Mapbox layers               | Day colors §1      |
+| `SplitView`                  | Map + sheet            | Map + `BottomSheetScaffold` | Map default Nearby |
+| `ChatMessage` + embeds       | Bubble + card stack    | Same                        | No nested blur     |
+| `ItineraryStreamView`        | Stop list + phase rail | Same                        | Reuse stop card    |
+| `WhyThisStop`                | Trust chip             | Trust chip                  |                    |
+| `Discover` cards             | Field card + stagger   | Same                        |                    |
+| `Nav` / tab bar              | TabView                | NavigationBar               | Four journeys      |
+| Auth                         | `SignIn` layout        | Same                        | Flat inputs        |
+| Settings field kit           | Section cards          | Same                        |                    |
+| PWA / FAB chat               | **Sheet or tab**       | **Sheet or tab**            | No web FAB clone   |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@buf/loci_loci-proto.bufbuild_es": "2.12.1-20260720203021-392270e1e2e5.1",
+    "@buf/loci_loci-proto.bufbuild_es": "2.12.1-20260721202904-f4c241e21387.1",
     "@bufbuild/protobuf": "^2.10.2",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-web": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@buf/loci_loci-proto.bufbuild_es':
-        specifier: 2.12.1-20260720203021-392270e1e2e5.1
-        version: 2.12.1-20260720203021-392270e1e2e5.1(@bufbuild/protobuf@2.12.1)
+        specifier: 2.12.1-20260721202904-f4c241e21387.1
+        version: 2.12.1-20260721202904-f4c241e21387.1(@bufbuild/protobuf@2.12.1)
       '@bufbuild/protobuf':
         specifier: ^2.10.2
         version: 2.12.1
@@ -676,8 +676,8 @@ packages:
     peerDependencies:
       '@bufbuild/protobuf': ^2.12.1
 
-  '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260720203021-392270e1e2e5.1':
-    resolution: {integrity: sha512-jzq0GP8N9vkpYMw7GrXG9t1ot8D1Q4KJwA485Qkea64FgMg7jnIsipnTGrXV/WfTQMPipuZWXM2Ohai8d3GjqQ==}
+  '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260721202904-f4c241e21387.1':
+    resolution: {integrity: sha512-1TeDSxtYRO4/+Kv8p7saWqzrfTnGKbQ2RTKajPb2KiRPlwDzxhBZd1Tmwa6GzAKedTf/lityKjPjaXS1xkPznQ==}
     peerDependencies:
       '@bufbuild/protobuf': ^2.12.1
 
@@ -6056,7 +6056,7 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 2.12.1
 
-  '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260720203021-392270e1e2e5.1(@bufbuild/protobuf@2.12.1)':
+  '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260721202904-f4c241e21387.1(@bufbuild/protobuf@2.12.1)':
     dependencies:
       '@buf/bufbuild_protovalidate.bufbuild_es': 2.12.1-20251209175733-2a1774d88802.1(@bufbuild/protobuf@2.12.1)
       '@buf/protocolbuffers_wellknowntypes.bufbuild_es': 2.12.1-20230331140314-f17e05fe4a76.1(@bufbuild/protobuf@2.12.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 allowBuilds:
-  '@parcel/watcher': false
+  "@parcel/watcher": false
   esbuild: false
   sharp: false
   workerd: false
 minimumReleaseAgeExclude:
-  - '@buf/loci_loci-proto.bufbuild_es@2.12.1-20260711223240-70152a17f3bd.1 || 2.12.1-20260717234410-076bdef9cb1c.1 || 2.12.1-20260718080757-48b85c78a107.1 || 2.12.1-20260720203021-392270e1e2e5.1'
+  - "@buf/loci_loci-proto.bufbuild_es@2.12.1-20260711223240-70152a17f3bd.1 || 2.12.1-20260717234410-076bdef9cb1c.1 || 2.12.1-20260718080757-48b85c78a107.1 || 2.12.1-20260720203021-392270e1e2e5.1 || 2.12.1-20260721202904-f4c241e21387.1"

--- a/src/app.css
+++ b/src/app.css
@@ -3,4 +3,6 @@
 
 @import "./styles/base.css";
 @import "./styles/themes.css";
+@import "./styles/motion-tokens.css";
 @import "./styles/theme-utilities.css";
+@import "./styles/animations.css";

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -39,7 +39,7 @@ export default function App() {
 
                         <div class="relative z-10 flex flex-col min-h-screen">
                           <Nav />
-                          <main class="relative flex-grow">
+                          <main class="relative flex-grow pb-20 md:pb-0">
                             <div class="relative min-h-screen">
                               <Suspense fallback={<PageLoading />}>{props.children}</Suspense>
                             </div>

--- a/src/components/AppearanceSettings.tsx
+++ b/src/components/AppearanceSettings.tsx
@@ -1,6 +1,5 @@
 import { For } from "solid-js";
-import { Sun, Moon, Monitor, Palette, Languages } from "lucide-solid";
-import ThemeSelector from "~/components/ThemeSelector";
+import { Sun, Moon, Monitor, Languages } from "lucide-solid";
 import { useTheme } from "~/contexts/ThemeContext";
 import { useLanguage } from "~/contexts/LanguageContext";
 import { SUPPORTED_LANGUAGES } from "~/lib/language-preference";
@@ -24,14 +23,6 @@ export default function AppearanceSettings(props: AppearanceSettingsProps) {
 
   return (
     <div class={props.compact ? "space-y-4" : "space-y-6"}>
-      <div class="space-y-3">
-        <div class="flex items-center gap-2">
-          <Palette class="w-4 h-4 text-muted-foreground" />
-          <Label>Design style</Label>
-        </div>
-        <ThemeSelector />
-      </div>
-
       <div class="space-y-3">
         <div class="flex items-center gap-2">
           <Sun class="w-4 h-4 text-muted-foreground" />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,159 +1,59 @@
-import { Building2 } from "lucide-solid";
+import { A } from "@solidjs/router";
+import { Compass, MapPin } from "lucide-solid";
 
-const linkClass =
-  "transition-colors duration-200 hover:text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background rounded";
+const links = [
+  { label: "Discover", href: "/discover" },
+  { label: "Nearby", href: "/nearme" },
+  { label: "Trips", href: "/trips" },
+  { label: "Ask Loci", href: "/chat" },
+  { label: "Contribute", href: "/contribute" },
+  { label: "Privacy", href: "/settings" },
+];
 
 export default function Footer() {
   return (
-    <footer class="relative isolate overflow-hidden bg-card text-foreground border-t border-border">
-      <div
-        class="absolute inset-0 opacity-50"
-        style={{
-          "background-image":
-            "radial-gradient(circle at 12% 18%, hsl(var(--primary) / 0.18), transparent 28%), radial-gradient(circle at 85% 12%, hsl(var(--accent) / 0.14), transparent 26%), radial-gradient(circle at 50% 120%, hsl(var(--primary) / 0.1), transparent 34%)",
-        }}
-        aria-hidden="true"
-      />
-      <div
-        class="absolute inset-0 bg-[linear-gradient(to_right,hsl(var(--border)/0.4)_1px,transparent_1px),linear-gradient(to_bottom,hsl(var(--border)/0.4)_1px,transparent_1px)] bg-[size:120px_120px] opacity-30 [mask-image:radial-gradient(circle_at_center,rgba(0,0,0,0.75),transparent_65%)]"
-        aria-hidden="true"
-      />
-      <div
-        class="absolute inset-x-0 top-1/3 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent opacity-70"
-        aria-hidden="true"
-      />
-
-      <div class="relative z-10 mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 py-12 sm:py-16 space-y-10">
-        <div class="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
-          <div class="max-w-sm space-y-4">
-            <div class="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary ring-1 ring-primary/20">
-              <span class="h-2 w-2 rounded-full bg-primary shadow-[0_0_0_6px_hsl(var(--primary)/0.18)]" />
-              <span>Intelligent locations, simplified</span>
-            </div>
-            <div class="flex items-center gap-3">
-              <div class="grid h-10 w-10 place-items-center rounded-2xl bg-muted ring-1 ring-border">
-                <Building2 class="h-5 w-5 text-primary" />
-              </div>
-              <div>
-                <p class="text-lg font-semibold tracking-tight text-foreground">Loci</p>
-                <p class="text-sm text-muted-foreground">
-                  Find, assess, and act on business opportunities with clarity.
-                </p>
-              </div>
-            </div>
-            <div class="flex flex-wrap gap-2 text-xs text-muted-foreground">
-              <span class="rounded-full bg-muted px-3 py-1 ring-1 ring-border">
-                Data-backed scouting
-              </span>
-              <span class="rounded-full bg-muted px-3 py-1 ring-1 ring-border">
-                AI recommendations
-              </span>
-              <span class="rounded-full bg-muted px-3 py-1 ring-1 ring-border">Team-ready</span>
+    <footer class="mt-20 border-t border-border bg-primary text-primary-foreground">
+      <div class="mx-auto grid max-w-7xl gap-10 px-4 py-12 sm:px-6 md:grid-cols-[1.2fr_1fr] lg:px-8">
+        <div class="max-w-lg">
+          <div class="mb-5 flex items-center gap-3">
+            <span class="grid h-10 w-10 place-items-center rounded-full border border-primary-foreground/30">
+              <MapPin class="h-5 w-5" />
+            </span>
+            <div>
+              <p class="font-serif text-2xl font-semibold">Loci</p>
+              <p class="font-coord text-[10px] uppercase tracking-[0.2em] text-primary-foreground/65">
+                Go somewhere worth remembering
+              </p>
             </div>
           </div>
-
-          <div class="grid grid-cols-2 gap-8 sm:grid-cols-3 lg:grid-cols-4">
-            <div class="space-y-3">
-              <h3 class="text-sm font-semibold text-foreground">Products</h3>
-              <ul class="space-y-2 text-sm text-muted-foreground">
-                <li>
-                  <a class={linkClass} href="#">
-                    Platform
-                  </a>
-                </li>
-                <li>
-                  <a class={linkClass} href="#">
-                    Enterprise
-                  </a>
-                </li>
-                <li>
-                  <a class={linkClass} href="#">
-                    API
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="space-y-3">
-              <h3 class="text-sm font-semibold text-foreground">Resources</h3>
-              <ul class="space-y-2 text-sm text-muted-foreground">
-                <li>
-                  <a class={linkClass} href="#">
-                    Blog
-                  </a>
-                </li>
-                <li>
-                  <a class={linkClass} href="#">
-                    Reports
-                  </a>
-                </li>
-                <li>
-                  <a class={linkClass} href="#">
-                    Help Center
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="space-y-3">
-              <h3 class="text-sm font-semibold text-foreground">Company</h3>
-              <ul class="space-y-2 text-sm text-muted-foreground">
-                <li>
-                  <a class={linkClass} href="/about">
-                    About
-                  </a>
-                </li>
-                <li>
-                  <a class={linkClass} href="#">
-                    Careers
-                  </a>
-                </li>
-                <li>
-                  <a class={linkClass} href="#">
-                    Contact
-                  </a>
-                </li>
-              </ul>
-            </div>
-            <div class="space-y-3">
-              <h3 class="text-sm font-semibold text-foreground">Stay in touch</h3>
-              <ul class="space-y-2 text-sm text-muted-foreground">
-                <li>
-                  <a class={linkClass} href="#">
-                    Status
-                  </a>
-                </li>
-                <li>
-                  <a class={linkClass} href="#">
-                    Security
-                  </a>
-                </li>
-                <li>
-                  <a class={linkClass} href="#">
-                    Press
-                  </a>
-                </li>
-              </ul>
-            </div>
-          </div>
+          <p class="max-w-md text-sm leading-6 text-primary-foreground/72">
+            A personal field guide for finding places that fit your taste, shaping them into
+            workable adventures, and learning from what you actually keep.
+          </p>
         </div>
 
-        <div class="flex flex-col gap-3 border-t border-border pt-6 text-sm sm:flex-row sm:items-center sm:justify-between">
-          <div class="flex items-center gap-2 text-foreground">
-            <Building2 class="h-4 w-4 text-primary" />
-            <span class="font-medium">Loci</span>
+        <div>
+          <p class="mb-4 font-coord text-[10px] uppercase tracking-[0.18em] text-primary-foreground/60">
+            Pack your route
+          </p>
+          <div class="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
+            {links.map((link) => (
+              <A
+                href={link.href}
+                class="text-primary-foreground/78 transition-colors hover:text-primary-foreground"
+              >
+                {link.label}
+              </A>
+            ))}
           </div>
-          <div class="flex flex-wrap gap-4 text-muted-foreground">
-            <a class={`${linkClass} hover:text-primary`} href="#">
-              Privacy
-            </a>
-            <a class={`${linkClass} hover:text-primary`} href="#">
-              Terms
-            </a>
-            <a class={`${linkClass} hover:text-primary`} href="#">
-              Support
-            </a>
+          <div class="mt-8 flex items-center gap-2 border-t border-primary-foreground/15 pt-5 text-xs text-primary-foreground/55">
+            <Compass class="h-4 w-4" />
+            <span>Built for curious travelers and useful detours.</span>
           </div>
-          <p class="text-muted-foreground">© 2026 Loci Inc. All rights reserved.</p>
         </div>
+      </div>
+      <div class="border-t border-primary-foreground/15 px-4 py-4 text-center font-coord text-[9px] uppercase tracking-[0.16em] text-primary-foreground/45">
+        © {new Date().getFullYear()} Loci · Recommendations explain themselves
       </div>
     </footer>
   );

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,469 +1,231 @@
-import { Badge } from "@/ui/badge";
-import { Button } from "@/ui/button";
-import { useLocation } from "@solidjs/router";
-import { A } from "@solidjs/router";
+import { A, useLocation } from "@solidjs/router";
 import {
-  Menu,
-  X,
-  User,
-  Settings,
-  LogOut,
-  MessageCircle,
-  Heart,
-  List,
-  MapPin,
-  Clock,
-  Compass,
   Bookmark,
-  CreditCard,
+  ChevronDown,
+  Clock3,
+  Compass,
+  Heart,
+  LogOut,
   Map,
+  MapPin,
+  Menu,
+  MessageCircle,
+  Settings,
+  Sparkles,
+  User,
+  Users,
+  X,
 } from "lucide-solid";
-import { createSignal, For, Show, onMount, onCleanup } from "solid-js";
-import { Portal } from "solid-js/web";
-import { ImageRoot, ImageFallback, Image } from "@/ui/image";
+import { createSignal, For, Show } from "solid-js";
+import { Dynamic } from "solid-js/web";
 import { useAuth } from "~/contexts/AuthContext";
-import PWAInstall from "~/components/PWAInstall";
 import ThemeSelector from "~/components/ThemeSelector";
-import EntitlementsBadge from "~/components/EntitlementsBadge";
+import { Button } from "~/ui/button";
 import { handleLinkPreload } from "~/lib/preload";
 
-// Public navigation items (for non-authenticated users)
-const publicNavigationItems = [
+const publicItems = [
+  { name: "How it works", href: "/features" },
   { name: "About", href: "/about" },
-  { name: "Features", href: "/features" },
   { name: "MCP", href: "/mcp" },
-  { name: "Roadmap", href: "/roadmap" },
   { name: "Pricing", href: "/pricing" },
 ];
 
-// Authenticated navigation items (main nav bar)
-const authNavigationItems = [
+const journeyItems = [
   { name: "Discover", href: "/discover", icon: Compass },
-  { name: "Near Me", href: "/nearme", icon: MapPin },
-  { name: "Recents", href: "/recents", icon: Clock },
+  { name: "Nearby", href: "/nearme", icon: MapPin },
   { name: "Trips", href: "/trips", icon: Map },
-  { name: "Chat", href: "/chat", icon: MessageCircle },
+  { name: "Ask Loci", href: "/chat", icon: MessageCircle },
 ];
 
-// User menu dropdown items
-const userMenuItems = [
+const accountItems = [
+  { name: "Contribute", href: "/contribute", icon: Users },
   { name: "Favorites", href: "/favorites", icon: Heart },
   { name: "Bookmarks", href: "/bookmarks", icon: Bookmark },
-  { name: "My Lists", href: "/lists", icon: List },
-  { name: "Profile", href: "/profiles", icon: User },
-  { name: "Billing", href: "/billing", icon: CreditCard, badge: "Pro" },
+  { name: "Recents", href: "/recents", icon: Clock3 },
+  { name: "Travel profiles", href: "/profiles", icon: User },
   { name: "Settings", href: "/settings", icon: Settings },
 ];
 
 export default function Nav() {
   const { isAuthenticated, user, logout, isLoading } = useAuth();
   const location = useLocation();
-  const [isMenuOpen, setIsMenuOpen] = createSignal(false);
-  const [showUserMenu, setShowUserMenu] = createSignal(false);
+  const [mobileOpen, setMobileOpen] = createSignal(false);
+  const [accountOpen, setAccountOpen] = createSignal(false);
 
-  const handleLogout = async () => {
-    try {
-      await logout();
-    } catch (error) {
-      console.error("Logout failed:", error);
-    }
-  };
-
-  // Close menus when clicking outside
-  onMount(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-      if (!target.closest(".user-menu-container") && showUserMenu()) {
-        setShowUserMenu(false);
-      }
-    };
-
-    document.addEventListener("click", handleClickOutside);
-    onCleanup(() => document.removeEventListener("click", handleClickOutside));
-  });
+  const initials = () =>
+    (user()?.display_name || user()?.username || user()?.email || "Traveler")
+      .slice(0, 1)
+      .toUpperCase();
 
   return (
-    <nav class="sticky top-0 z-50 transition-all">
-      <div class="island-nav px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between items-center h-14 sm:h-16">
-          {/* Logo - Mobile First */}
-          <div class="flex items-center">
-            <A href="/" class="flex items-center">
-              <div class="w-6 h-6 sm:w-8 sm:h-8 flex items-center justify-center">
-                <ImageRoot>
-                  <Image
-                    src="/images/loci-abstract-symbol.svg"
-                    alt="Loci logo"
-                    class="w-full h-full object-contain"
-                  />
-                  <ImageFallback class="w-full h-full bg-primary text-primary-foreground rounded flex items-center justify-center text-sm font-bold">
-                    L
-                  </ImageFallback>
-                </ImageRoot>
-              </div>
-              <span class="ml-2 text-lg sm:text-xl font-bold text-foreground tracking-tight transition-colors">
+    <>
+      <nav class="sticky top-0 z-50 island-nav">
+        <div class="mx-auto flex h-16 max-w-7xl items-center gap-6 px-4 sm:px-6 lg:px-8">
+          <A href="/" class="group flex shrink-0 items-center gap-3" aria-label="Loci home">
+            <span class="relative grid h-9 w-9 place-items-center rounded-full border border-primary bg-primary text-primary-foreground">
+              <MapPin class="h-4 w-4" />
+              <span class="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full border-2 border-background bg-accent" />
+            </span>
+            <span>
+              <span class="block font-serif text-xl font-semibold leading-none tracking-tight">
                 Loci
               </span>
-              <Show when={isAuthenticated()}>
-                <Badge
-                  variant="secondary"
-                  class="ml-1 sm:ml-2 bg-primary/10 text-primary border border-primary/30 text-xs px-1.5 py-0.5 sm:px-2 sm:py-1"
-                >
-                  AI
-                </Badge>
-              </Show>
-            </A>
-          </div>
+              <span class="font-coord hidden text-[9px] uppercase tracking-[0.2em] text-muted-foreground sm:block">
+                Field guide
+              </span>
+            </span>
+          </A>
 
-          {/* Mobile Menu Button */}
-          <Button
-            variant="ghost"
-            size="sm"
-            class="md:hidden p-2 text-foreground hover:text-primary"
-            onClick={() => setIsMenuOpen(!isMenuOpen())}
-            aria-label={isMenuOpen() ? "Close menu" : "Open menu"}
-          >
-            <Show when={!isMenuOpen()} fallback={<X class="w-5 h-5" />}>
-              <Menu class="w-5 h-5" />
-            </Show>
-          </Button>
-
-          {/* Desktop Navigation */}
           <Show when={!isLoading()}>
-            <Show
-              when={isAuthenticated()}
-              fallback={
-                <div class="hidden md:flex items-center space-x-6 lg:space-x-8">
-                  <For each={publicNavigationItems}>
-                    {(item) => (
-                      <A
-                        href={item.href}
-                        class="text-muted-foreground hover:text-primary font-medium transition-colors text-sm lg:text-base jb-tab"
-                        activeClass="jb-tab-active"
-                      >
-                        {item.name}
-                      </A>
-                    )}
-                  </For>
-                </div>
-              }
-            >
-              <div class="hidden md:flex items-center space-x-1">
-                <For each={authNavigationItems}>
-                  {(item) => {
-                    const IconComponent = item.icon;
-                    return (
-                      <A
-                        href={item.href}
-                        onMouseEnter={() => handleLinkPreload(item.href)}
-                        class="flex items-center gap-2 px-3 py-2 rounded-xl font-medium transition-all text-sm border border-transparent jb-tab hover:bg-muted"
-                        activeClass="jb-tab-active shadow-sm"
-                      >
-                        <IconComponent class="w-4 h-4" />
-                        {item.name}
-                        <Show when={(item as any).experimental}>
-                          <Badge
-                            variant="secondary"
-                            class="ml-1 bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-300 border border-orange-300 dark:border-orange-700 text-xs px-1.5 py-0.5"
-                          >
-                            Experimental
-                          </Badge>
-                        </Show>
-                      </A>
-                    );
-                  }}
-                </For>
-                <EntitlementsBadge />
-              </div>
-            </Show>
-          </Show>
-
-          {/* Desktop User Menu or Auth Buttons */}
-          <Show when={!isLoading()}>
-            <Show
-              when={isAuthenticated()}
-              fallback={
-                <div class="hidden md:flex items-center space-x-3 lg:space-x-4">
-                  {/* PWA Install Button */}
-                  <PWAInstall />
-
-                  {/* Theme Selector for non-authenticated users */}
-                  <ThemeSelector />
-
-                  <A href="/auth/signin">
-                    <Button
-                      variant="ghost"
-                      class="text-muted-foreground hover:text-primary text-sm lg:text-base px-3 lg:px-4 font-semibold"
+            <div class="hidden flex-1 items-center justify-center gap-1 md:flex">
+              <For each={isAuthenticated() ? journeyItems : publicItems}>
+                {(item) => {
+                  const Icon = "icon" in item ? (item.icon as typeof Compass) : undefined;
+                  return (
+                    <A
+                      href={item.href}
+                      onMouseEnter={() => handleLinkPreload(item.href)}
+                      class="jb-tab flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
+                      activeClass="jb-tab-active"
                     >
-                      Log In
-                    </Button>
-                  </A>
-                  <A href="/auth/signup">
-                    <Button class="text-sm lg:text-base px-3 lg:px-4 bg-primary hover:bg-primary/90 text-primary-foreground font-semibold shadow-lg">
-                      Get Started
-                    </Button>
-                  </A>
-                </div>
-              }
-            >
-              <div class="hidden md:flex items-center space-x-3 relative user-menu-container">
-                {/* PWA Install Button */}
-                <PWAInstall />
+                      <Show when={Icon}>
+                        <Dynamic component={Icon} class="h-4 w-4" />
+                      </Show>
+                      {item.name}
+                    </A>
+                  );
+                }}
+              </For>
+            </div>
 
-                {/* Theme Selector */}
-                <ThemeSelector />
-
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setShowUserMenu(!showUserMenu())}
-                  class="flex items-center gap-2 p-2 text-foreground hover:text-primary"
-                >
-                  <div class="w-8 h-8 rounded-full bg-primary flex items-center justify-center text-primary-foreground text-sm font-bold shadow-lg ring-2 ring-primary/30">
-                    {(user()?.display_name || user()?.username || user()?.email || "U")
-                      .charAt(0)
-                      .toUpperCase()}
-                  </div>
-                  <span class="text-sm font-semibold text-foreground">
-                    {user()?.display_name || user()?.username || user()?.email || "Guest"}
-                  </span>
-                </Button>
-
-                {/* User Dropdown Menu */}
-                <Show when={showUserMenu()}>
-                  <div class="absolute top-full right-0 mt-2 w-56 bg-popover/95 backdrop-blur-xl rounded-2xl shadow-lg border border-border py-2 z-50 transition-colors">
-                    {/* User Menu Items */}
-                    <For each={userMenuItems}>
-                      {(item) => {
-                        const IconComponent = item.icon;
-                        return (
-                          <A
-                            href={item.href}
-                            class={`flex items-center gap-3 px-4 py-2.5 text-sm font-medium transition-colors mx-1 rounded-lg ${
-                              location.pathname === item.href
-                                ? "bg-primary/10 text-primary"
-                                : "text-muted-foreground hover:bg-muted"
-                            }`}
-                            onClick={() => setShowUserMenu(false)}
-                          >
-                            <IconComponent class="w-4 h-4" />
-                            {item.name}
-                            <Show when={(item as any).badge}>
-                              <Badge
-                                variant="secondary"
-                                class="ml-auto bg-gradient-to-r from-purple-100 to-blue-100 dark:from-purple-900/40 dark:to-blue-900/40 text-purple-700 dark:text-purple-300 border border-purple-200 dark:border-purple-700/50 text-xs px-1.5 py-0.5"
-                              >
-                                {(item as any).badge}
-                              </Badge>
-                            </Show>
-                          </A>
-                        );
-                      }}
-                    </For>
-
-                    {/* Divider */}
-                    <div class="my-2 mx-3 border-t border-border" />
-
-                    {/* Sign Out */}
-                    <button
-                      onClick={() => {
-                        setShowUserMenu(false);
-                        handleLogout();
-                      }}
-                      class="w-full flex items-center gap-3 px-4 py-2.5 text-sm font-medium text-destructive hover:bg-destructive/10 transition-colors rounded-lg mx-1"
-                    >
-                      <LogOut class="w-4 h-4" />
-                      Sign Out
-                    </button>
-                  </div>
-                </Show>
-              </div>
-            </Show>
-          </Show>
-        </div>
-      </div>
-
-      <Show when={isMenuOpen()}>
-        <Portal>
-          <div class="md:hidden fixed inset-0 z-[100] transition-all duration-300">
-            {/* Glassy Background Layer */}
-            <div class="absolute inset-0 bg-background/80 backdrop-blur-3xl" />
-
-            <div class="relative flex flex-col h-full overflow-y-auto">
-              {/* Mobile Header */}
-              {/* Mobile Header */}
-              <div class="flex justify-between items-center px-4 sm:px-6 py-4 border-b border-border/50 bg-card/50 backdrop-blur-sm sticky top-0 z-10 h-14 sm:h-16">
-                <div class="flex items-center">
-                  <div class="w-6 h-6 sm:w-8 sm:h-8 flex items-center justify-center">
-                    <ImageRoot>
-                      <Image
-                        src="/images/loci-abstract-symbol.svg"
-                        alt="Loci logo"
-                        class="w-full h-full object-contain"
-                      />
-                      <ImageFallback class="w-full h-full bg-primary text-primary-foreground rounded flex items-center justify-center text-sm font-bold">
-                        L
-                      </ImageFallback>
-                    </ImageRoot>
-                  </div>
-                  <span class="ml-2 text-lg sm:text-xl font-bold text-foreground tracking-tight">
-                    Loci
-                  </span>
-                  <Show when={isAuthenticated()}>
-                    <Badge
-                      variant="secondary"
-                      class="ml-1 sm:ml-2 bg-primary/10 text-primary border border-primary/30 text-xs px-1.5 py-0.5 sm:px-2 sm:py-1"
-                    >
-                      AI
-                    </Badge>
-                  </Show>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  class="md:hidden p-2 text-foreground hover:bg-muted rounded-full"
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  <X class="w-6 h-6" />
-                </Button>
-              </div>
-
-              {/* Mobile Navigation Links - Clean List Style */}
-              <div class="flex-1 px-6 py-2">
-                <Show when={!isLoading()}>
-                  <div class="flex flex-col">
-                    {/* Public Items */}
-                    <Show when={!isAuthenticated()}>
-                      <For each={publicNavigationItems}>
+            <div class="ml-auto hidden items-center gap-2 md:flex">
+              <ThemeSelector />
+              <Show
+                when={isAuthenticated()}
+                fallback={
+                  <>
+                    <A href="/auth/signin" class="px-3 py-2 text-sm font-semibold text-foreground">
+                      Sign in
+                    </A>
+                    <A href="/auth/signup">
+                      <Button class="gap-2 rounded-lg">
+                        <Sparkles class="h-4 w-4" />
+                        Start exploring
+                      </Button>
+                    </A>
+                  </>
+                }
+              >
+                <div class="relative">
+                  <button
+                    type="button"
+                    onClick={() => setAccountOpen(!accountOpen())}
+                    class="flex items-center gap-2 rounded-lg border border-border bg-card px-2 py-1.5 text-sm font-semibold hover:border-accent"
+                    aria-expanded={accountOpen()}
+                  >
+                    <span class="grid h-8 w-8 place-items-center rounded-full bg-secondary text-xs text-secondary-foreground">
+                      {initials()}
+                    </span>
+                    <span class="max-w-28 truncate">
+                      {user()?.display_name || user()?.username || "Traveler"}
+                    </span>
+                    <ChevronDown class="h-4 w-4 text-muted-foreground" />
+                  </button>
+                  <Show when={accountOpen()}>
+                    <div class="absolute right-0 top-full mt-2 w-60 rounded-xl border border-border bg-popover p-2 shadow-xl">
+                      <p class="px-3 pb-2 pt-1 font-coord text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+                        Your field kit
+                      </p>
+                      <For each={accountItems}>
                         {(item) => (
                           <A
                             href={item.href}
-                            class="group flex items-center justify-between py-5 text-lg font-medium text-foreground border-b border-border/50 active:bg-muted transition-colors"
-                            onClick={() => setIsMenuOpen(false)}
+                            onClick={() => setAccountOpen(false)}
+                            class="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-muted-foreground hover:bg-secondary hover:text-foreground"
                           >
+                            <Dynamic component={item.icon} class="h-4 w-4" />
                             {item.name}
-                            <span class="text-muted-foreground/60 group-hover:translate-x-1 transition-transform">
-                              →
-                            </span>
                           </A>
                         )}
                       </For>
-                    </Show>
-
-                    {/* Authenticated Items */}
-                    <Show when={isAuthenticated()}>
-                      <For each={authNavigationItems}>
-                        {(item) => {
-                          const IconComponent = item.icon;
-                          return (
-                            <A
-                              href={item.href}
-                              onTouchStart={() => handleLinkPreload(item.href)}
-                              class="group flex items-center justify-between py-5 text-lg font-medium text-foreground border-b border-border/50 active:bg-muted transition-colors"
-                              onClick={() => setIsMenuOpen(false)}
-                            >
-                              <div class="flex items-center gap-4">
-                                <span class="p-2 rounded-lg bg-muted text-muted-foreground">
-                                  <IconComponent class="w-5 h-5" />
-                                </span>
-                                <div class="flex items-center gap-2">
-                                  {item.name}
-                                  <Show when={(item as any).experimental}>
-                                    <Badge
-                                      variant="secondary"
-                                      class="bg-orange-100 dark:bg-orange-900/40 text-orange-800 dark:text-orange-200 border border-orange-200 dark:border-orange-700/50 text-[10px] px-1.5 py-0.5 uppercase tracking-wider"
-                                    >
-                                      Beta
-                                    </Badge>
-                                  </Show>
-                                </div>
-                              </div>
-                              <span class="text-muted-foreground/60 group-hover:translate-x-1 transition-transform">
-                                →
-                              </span>
-                            </A>
-                          );
-                        }}
-                      </For>
-                    </Show>
-                  </div>
-                </Show>
-              </div>
-
-              {/* Mobile Footer / User Action Area */}
-              <Show when={!isLoading()}>
-                <div class="p-6 mt-auto bg-card/50 backdrop-blur-md border-t border-border/50">
-                  <Show
-                    when={!isAuthenticated()}
-                    fallback={
-                      <div class="space-y-6">
-                        {/* User Info */}
-                        <div class="flex items-center gap-4">
-                          <div class="w-12 h-12 rounded-full bg-primary flex items-center justify-center text-primary-foreground text-xl font-bold shadow-lg ring-2 ring-primary/30">
-                            {user()?.username?.charAt(0).toUpperCase() || "U"}
-                          </div>
-                          <div class="flex-1 min-w-0">
-                            <div class="font-bold text-lg text-foreground truncate">
-                              {user()?.username || "User"}
-                            </div>
-                            <div class="text-sm text-muted-foreground truncate">
-                              {user()?.email}
-                            </div>
-                          </div>
-                          <ThemeSelector />
-                        </div>
-
-                        {/* Actions Grid */}
-                        <div class="grid grid-cols-2 gap-3">
-                          <A href="/settings" class="w-full" onClick={() => setIsMenuOpen(false)}>
-                            <Button
-                              variant="outline"
-                              class="w-full justify-center h-12 text-base border-border bg-card/50 text-foreground hover:bg-muted"
-                            >
-                              Settings
-                            </Button>
-                          </A>
-                          <Button
-                            onClick={() => {
-                              setIsMenuOpen(false);
-                              handleLogout();
-                            }}
-                            variant="outline"
-                            class="w-full justify-center h-12 text-base text-destructive border-destructive/30 bg-destructive/10 hover:bg-destructive/20"
-                          >
-                            Sign Out
-                          </Button>
-                        </div>
-                      </div>
-                    }
-                  >
-                    {/* Guest Actions */}
-                    <div class="space-y-4">
-                      <div class="flex justify-between items-center mb-4">
-                        <span class="text-sm font-medium text-muted-foreground">Appearance</span>
-                        <ThemeSelector />
-                      </div>
-                      <A href="/auth/signin" class="block" onClick={() => setIsMenuOpen(false)}>
-                        <Button
-                          variant="outline"
-                          class="w-full justify-center h-12 text-base font-semibold border-border bg-card/50 text-foreground"
-                        >
-                          Log In
-                        </Button>
-                      </A>
-                      <A href="/auth/signup" class="block" onClick={() => setIsMenuOpen(false)}>
-                        <Button class="w-full justify-center h-12 text-base font-bold bg-primary hover:bg-primary/90 text-primary-foreground shadow-lg">
-                          Get Started
-                        </Button>
-                      </A>
+                      <div class="my-2 border-t border-border" />
+                      <button
+                        type="button"
+                        onClick={() => void logout()}
+                        class="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm text-destructive hover:bg-destructive/10"
+                      >
+                        <LogOut class="h-4 w-4" />
+                        Sign out
+                      </button>
                     </div>
                   </Show>
                 </div>
               </Show>
             </div>
+          </Show>
+
+          <button
+            type="button"
+            class="ml-auto grid h-10 w-10 place-items-center rounded-lg border border-border md:hidden"
+            onClick={() => setMobileOpen(!mobileOpen())}
+            aria-label={mobileOpen() ? "Close navigation" : "Open navigation"}
+          >
+            {mobileOpen() ? <X class="h-5 w-5" /> : <Menu class="h-5 w-5" />}
+          </button>
+        </div>
+
+        <Show when={mobileOpen()}>
+          <div class="border-t border-border bg-background px-4 py-4 md:hidden">
+            <div class="grid gap-1">
+              <For each={isAuthenticated() ? accountItems : publicItems}>
+                {(item) => {
+                  const Icon = "icon" in item ? (item.icon as typeof Compass) : undefined;
+                  return (
+                    <A
+                      href={item.href}
+                      onClick={() => setMobileOpen(false)}
+                      class="flex items-center gap-3 rounded-lg px-3 py-3 text-sm font-medium text-foreground hover:bg-secondary"
+                    >
+                      <Show when={Icon}>
+                        <Dynamic component={Icon} class="h-4 w-4" />
+                      </Show>
+                      {item.name}
+                    </A>
+                  );
+                }}
+              </For>
+              <div class="mt-3 flex items-center justify-between border-t border-border pt-3">
+                <ThemeSelector />
+                <Show when={!isAuthenticated()}>
+                  <A href="/auth/signup" onClick={() => setMobileOpen(false)}>
+                    <Button>Start exploring</Button>
+                  </A>
+                </Show>
+              </div>
+            </div>
           </div>
-        </Portal>
+        </Show>
+      </nav>
+
+      <Show when={isAuthenticated() && !isLoading()}>
+        <nav class="fixed inset-x-3 bottom-3 z-50 grid grid-cols-4 rounded-2xl border border-border bg-background/95 p-1.5 shadow-xl backdrop-blur md:hidden">
+          <For each={journeyItems}>
+            {(item) => {
+              const Icon = item.icon;
+              const active = () => location.pathname.startsWith(item.href);
+              return (
+                <A
+                  href={item.href}
+                  class={`flex min-h-12 flex-col items-center justify-center gap-1 rounded-xl text-[10px] font-semibold transition-colors ${active() ? "bg-secondary text-foreground" : "text-muted-foreground"}`}
+                >
+                  <Icon class="h-4 w-4" />
+                  {item.name === "Ask Loci" ? "Ask" : item.name}
+                </A>
+              );
+            }}
+          </For>
+        </nav>
       </Show>
-    </nav>
+    </>
   );
 }

--- a/src/components/PageBackground.tsx
+++ b/src/components/PageBackground.tsx
@@ -1,34 +1,11 @@
-/**
- * PageBackground is the app's ambient chrome: a faint cartographic contour
- * grid with a single soft accent wash, matching the landing redesign. It is
- * token-driven, so it adapts across the loci/classic/modern theme families
- * and light/dark without per-route color. Static — nothing to reduce for
- * prefers-reduced-motion.
- */
 export default function PageBackground() {
   return (
-    <div class="absolute inset-0 -z-10 overflow-hidden" aria-hidden="true">
-      {/* contour grid */}
-      <div
-        class="absolute inset-0"
-        style={{
-          "background-image":
-            "linear-gradient(hsl(var(--border)) 1px, transparent 1px), linear-gradient(90deg, hsl(var(--border)) 1px, transparent 1px)",
-          "background-size": "48px 48px",
-          "background-position": "-1px -1px",
-          "-webkit-mask-image": "radial-gradient(115% 85% at 50% 0%, black 28%, transparent 72%)",
-          "mask-image": "radial-gradient(115% 85% at 50% 0%, black 28%, transparent 72%)",
-          opacity: "0.6",
-        }}
-      />
-      {/* soft accent wash, top */}
-      <div
-        class="absolute inset-0"
-        style={{
-          background:
-            "radial-gradient(55% 38% at 50% -4%, hsl(var(--accent) / 0.10), transparent 62%)",
-        }}
-      />
+    <div class="pointer-events-none absolute inset-0 -z-10 overflow-hidden" aria-hidden="true">
+      <div class="absolute -right-40 top-24 h-[34rem] w-[34rem] rounded-full border border-[hsl(var(--map-line)/0.24)]" />
+      <div class="absolute -right-24 top-40 h-[25rem] w-[25rem] rounded-full border border-[hsl(var(--map-line)/0.2)]" />
+      <div class="absolute -right-8 top-56 h-[16rem] w-[16rem] rounded-full border border-[hsl(var(--map-line)/0.18)]" />
+      <div class="absolute -left-52 top-[42rem] h-[30rem] w-[30rem] rounded-[46%] border border-[hsl(var(--map-line)/0.18)] rotate-12" />
+      <div class="absolute -left-36 top-[47rem] h-[20rem] w-[20rem] rounded-[44%] border border-[hsl(var(--map-line)/0.16)] rotate-12" />
     </div>
   );
 }

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,67 +1,18 @@
-import { Sun, Moon, Palette } from "lucide-solid";
+import { Moon, Sun } from "lucide-solid";
 import { useTheme } from "~/contexts/ThemeContext";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/ui/select";
-import type { DesignTheme } from "~/lib/theme-preference";
-
-interface ThemeOption {
-  value: DesignTheme;
-  label: string;
-  description: string;
-}
-
-const themeOptions: ThemeOption[] = [
-  { value: "loci", label: "Loci", description: "Bold structural design" },
-  { value: "classic", label: "Classic", description: "Editorial luxury" },
-  { value: "modern", label: "Modern", description: "Clean functional" },
-];
 
 export default function ThemeSelector() {
-  const { isDark, toggleTheme, designTheme, setDesignTheme } = useTheme();
-
-  const currentTheme = () => themeOptions.find((t) => t.value === designTheme()) || themeOptions[0];
+  const { isDark, toggleTheme } = useTheme();
 
   return (
-    <div class="flex items-center gap-3 p-1.5 rounded-2xl bg-card/80 backdrop-blur-xl border border-border shadow-sm">
-      <button
-        type="button"
-        onClick={toggleTheme}
-        class="relative p-2.5 rounded-xl bg-muted/60 border border-border hover:bg-muted transition-all duration-200 hover:scale-105 active:scale-95 group"
-        title={isDark() ? "Switch to light mode" : "Switch to dark mode"}
-      >
-        {isDark() ? (
-          <Sun class="w-4 h-4 text-accent relative z-10" />
-        ) : (
-          <Moon class="w-4 h-4 text-muted-foreground relative z-10" />
-        )}
-      </button>
-
-      <Select<ThemeOption>
-        value={currentTheme()}
-        onChange={(option) => option && setDesignTheme(option.value)}
-        options={themeOptions}
-        optionValue="value"
-        optionTextValue="label"
-        itemComponent={(props) => (
-          <SelectItem item={props.item} class="rounded-lg hover:bg-muted/60 transition-colors">
-            <div class="flex flex-col py-0.5">
-              <span class="font-semibold text-sm">{props.item.rawValue.label}</span>
-              <span class="text-[11px] text-muted-foreground">{props.item.rawValue.description}</span>
-            </div>
-          </SelectItem>
-        )}
-      >
-        <SelectTrigger class="w-[150px] h-10 px-3 rounded-xl bg-muted/60 border border-border hover:bg-muted transition-all focus:ring-2 focus:ring-ring/30">
-          <div class="flex items-center gap-2">
-            <div class="p-1 rounded-md bg-primary/10">
-              <Palette class="w-3.5 h-3.5 text-primary" />
-            </div>
-            <SelectValue<ThemeOption>>
-              {(state) => <span class="font-medium text-sm">{state.selectedOption()?.label}</span>}
-            </SelectValue>
-          </div>
-        </SelectTrigger>
-        <SelectContent class="rounded-xl border border-border bg-popover/95 backdrop-blur-xl shadow-lg overflow-hidden" />
-      </Select>
-    </div>
+    <button
+      type="button"
+      onClick={toggleTheme}
+      class="grid h-10 w-10 place-items-center rounded-lg border border-border bg-card text-foreground transition-colors hover:border-accent hover:text-accent"
+      title={isDark() ? "Use light appearance" : "Use dark appearance"}
+      aria-label={isDark() ? "Use light appearance" : "Use dark appearance"}
+    >
+      {isDark() ? <Sun class="h-4 w-4" /> : <Moon class="h-4 w-4" />}
+    </button>
   );
 }

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -25,7 +25,7 @@ const ChatInput: Component<ChatInputProps> = (props) => {
   };
 
   return (
-    <div class="bg-popover/80 backdrop-blur-xl border-t border-border p-3 sm:p-4 shadow-[0_-4px_20px_rgba(0,0,0,0.05)]">
+    <div class="bg-popover border-t border-border p-3 sm:p-4">
       <div class="max-w-3xl mx-auto">
         <div class="flex items-end gap-2 sm:gap-3">
           <TextFieldRoot class="flex-1">

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -182,8 +182,8 @@ const ChatMessage: Component<ChatMessageProps> = (props) => {
               isUser()
                 ? "bg-primary text-primary-foreground shadow-primary/20"
                 : isError()
-                  ? "bg-destructive/10 text-destructive border border-destructive/30 backdrop-blur-sm"
-                  : "bg-card/80 text-foreground backdrop-blur-sm border border-border"
+                  ? "bg-destructive/10 text-destructive border border-destructive/30"
+                  : "loci-card text-foreground"
             }`}
           >
             <Show
@@ -196,7 +196,7 @@ const ChatMessage: Component<ChatMessageProps> = (props) => {
         </Show>
 
         <Show when={props.message.streamingData}>
-          <div class="mt-2 sm:mt-3 bg-card/90 backdrop-blur-xl border border-border rounded-xl p-3 sm:p-4 shadow-lg">
+          <div class="mt-2 sm:mt-3 loci-card rounded-xl p-3 sm:p-4 motion-enter">
             <Show when={cityData()}>
               <div class="flex items-center justify-between mb-2 sm:mb-3">
                 <div class="min-w-0 flex-1 pr-2">

--- a/src/components/chat/ChatQuickPrompts.tsx
+++ b/src/components/chat/ChatQuickPrompts.tsx
@@ -1,10 +1,12 @@
-import { For, Component } from "solid-js";
+import { For, Component, type Component as SolidComponent } from "solid-js";
+import { Bed, Compass, Map, Sparkles, Utensils } from "lucide-solid";
 
 export interface QuickPrompt {
   id: string;
   text: string;
   description: string;
-  icon: string;
+  /** Legacy emoji field — ignored when domain icon is used. */
+  icon?: string;
   domain: "accommodation" | "dining" | "activities" | "itinerary" | "general";
 }
 
@@ -13,32 +15,50 @@ export interface ChatQuickPromptsProps {
   onSelect: (prompt: QuickPrompt) => void;
 }
 
+const domainIcon = (domain: QuickPrompt["domain"]): SolidComponent<{ class?: string }> => {
+  switch (domain) {
+    case "accommodation":
+      return Bed;
+    case "dining":
+      return Utensils;
+    case "itinerary":
+      return Map;
+    case "activities":
+      return Sparkles;
+    default:
+      return Compass;
+  }
+};
+
 const ChatQuickPrompts: Component<ChatQuickPromptsProps> = (props) => {
   return (
     <div class="max-w-4xl mx-auto">
-      <h3 class="text-base sm:text-lg font-semibold text-foreground mb-3 sm:mb-4">
-        Try asking about:
+      <h3 class="font-serif text-base sm:text-lg font-semibold text-foreground mb-3 sm:mb-4">
+        Try asking about
       </h3>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
         <For each={props.prompts}>
-          {(prompt) => (
-            <button
-              onClick={() => props.onSelect(prompt)}
-              class="glass-panel rounded-xl hover:shadow-lg hover:border-primary/30 transition-all duration-300 p-3 sm:p-4 text-left group"
-            >
-              <div class="flex items-start gap-2 sm:gap-3">
-                <span class="text-xl sm:text-2xl flex-shrink-0 group-hover:scale-110 transition-transform">
-                  {prompt.icon}
-                </span>
-                <div class="min-w-0 flex-1">
-                  <h4 class="font-medium text-foreground mb-1 text-sm sm:text-base group-hover:text-primary transition-colors">
-                    {prompt.text}
-                  </h4>
-                  <p class="text-xs sm:text-sm text-muted-foreground">{prompt.description}</p>
+          {(prompt) => {
+            const Icon = domainIcon(prompt.domain);
+            return (
+              <button
+                onClick={() => props.onSelect(prompt)}
+                class="loci-card-interactive rounded-xl p-3 sm:p-4 text-left group min-h-[44px]"
+              >
+                <div class="flex items-start gap-2 sm:gap-3">
+                  <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-border bg-secondary text-primary motion-settle group-hover:border-primary/30">
+                    <Icon class="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <div class="min-w-0 flex-1">
+                    <h4 class="font-medium text-foreground mb-1 text-sm sm:text-base group-hover:text-primary transition-colors">
+                      {prompt.text}
+                    </h4>
+                    <p class="text-xs sm:text-sm text-muted-foreground">{prompt.description}</p>
+                  </div>
                 </div>
-              </div>
-            </button>
-          )}
+              </button>
+            );
+          }}
         </For>
       </div>
     </div>

--- a/src/components/features/Auth/SignIn.tsx
+++ b/src/components/features/Auth/SignIn.tsx
@@ -17,7 +17,7 @@ interface FormData {
 }
 
 const inputBase =
-  "w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-lg transition-all text-sm sm:text-base border bg-background text-foreground placeholder:text-muted-foreground backdrop-blur";
+  "w-full px-3 sm:px-4 py-2.5 sm:py-3 rounded-lg transition-all text-sm sm:text-base border border-input bg-background text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
 const SignIn: Component = () => {
   const { login } = useAuth();
@@ -213,7 +213,10 @@ const SignIn: Component = () => {
             <CheckboxControl />
             <span class="text-muted-foreground">Remember me</span>
           </Checkbox>
-          <A href="/auth/forgot-password" class="text-primary hover:text-primary/80 underline-offset-4">
+          <A
+            href="/auth/forgot-password"
+            class="text-primary hover:text-primary/80 underline-offset-4"
+          >
             Forgot password?
           </A>
         </div>

--- a/src/components/features/Chat/FloatingChat.tsx
+++ b/src/components/features/Chat/FloatingChat.tsx
@@ -42,8 +42,8 @@ export const FloatingChat: Component<FloatingChatProps> = (props) => {
       isLoading={isLoading()}
       sendChatMessage={sendChatMessage}
       handleKeyPress={handleKeyPress}
-      title="Loci Assistant"
-      placeholder="Ask about your trip..."
+      title="Ask Loci"
+      placeholder="Ask about places, routes, or your trip…"
     />
   );
 };

--- a/src/components/features/Map/Map.tsx
+++ b/src/components/features/Map/Map.tsx
@@ -1,7 +1,7 @@
 import { onMount, onCleanup, createEffect, mergeProps } from "solid-js";
 import mapboxgl from "mapbox-gl";
 import { useTheme } from "~/contexts/ThemeContext";
-import { mapStyleForColorMode } from "~/lib/theme-colors";
+import { colorForMapDay, LOCI_MAP_CLUSTER_COLOR, mapStyleForColorMode } from "~/lib/theme-colors";
 
 export interface POI {
   id: string;
@@ -36,21 +36,9 @@ interface MapComponentProps {
   onActivate?: (poi: POI, index: number) => void;
   /** Swap Mapbox light/dark basemap when color mode changes. Default true. */
   followColorMode?: boolean;
+  /** When true, map fills container edge-to-edge (no inset radius). */
+  fullBleed?: boolean;
 }
-
-// One stable colour per itinerary day. Index past the end wraps.
-const DAY_COLORS = [
-  "#ef4444", // red
-  "#3b82f6", // blue
-  "#10b981", // green
-  "#f59e0b", // amber
-  "#8b5cf6", // violet
-  "#ec4899", // pink
-  "#14b8a6", // teal
-  "#f97316", // orange
-];
-const colorForDay = (day?: number) =>
-  typeof day === "number" ? DAY_COLORS[day % DAY_COLORS.length] : "#64748b"; // slate for ungrouped
 
 const SOURCE_POIS = "loci-pois";
 const SOURCE_ROUTES = "loci-routes";
@@ -111,7 +99,8 @@ const MapComponent = (_props: MapComponentProps) => {
     meta.className = `map-popup__meta flex items-center justify-between ${isMobile ? "text-xs" : "text-sm"}`;
     if (poi.rating != null) {
       const rating = document.createElement("span");
-      rating.textContent = `⭐ ${poi.rating}`;
+      rating.className = "font-coord";
+      rating.textContent = `${poi.rating.toFixed(1)} rating`;
       meta.appendChild(rating);
     }
     if (poi.timeToSpend) {
@@ -129,8 +118,8 @@ const MapComponent = (_props: MapComponentProps) => {
 
     if (poi.dogFriendly) {
       const badge = document.createElement("div");
-      badge.className = `map-popup__badge mt-2 ${isMobile ? "text-xs" : "text-sm"} px-2 py-1 rounded-full inline-block`;
-      badge.textContent = "🐕 Dog Friendly";
+      badge.className = `map-popup__badge ui-label mt-2 ${isMobile ? "text-xs" : "text-sm"} px-2 py-1 rounded-md inline-block`;
+      badge.textContent = "Dog friendly";
       container.appendChild(badge);
     }
 
@@ -165,7 +154,7 @@ const MapComponent = (_props: MapComponentProps) => {
         id: fid,
         properties: {
           name: poi.name,
-          color: colorForDay(poi.day),
+          color: colorForMapDay(poi.day),
           label: String(poi.seq ?? i + 1),
         },
         geometry: { type: "Point", coordinates: [toNum(poi.longitude), toNum(poi.latitude)] },
@@ -185,7 +174,7 @@ const MapComponent = (_props: MapComponentProps) => {
       if (coords.length > 1) {
         routeFeatures.push({
           type: "Feature",
-          properties: { color: colorForDay(day) },
+          properties: { color: colorForMapDay(day) },
           geometry: { type: "LineString", coordinates: coords },
         });
       }
@@ -213,6 +202,23 @@ const MapComponent = (_props: MapComponentProps) => {
     }
   };
 
+  let routeAnimFrame: number | undefined;
+
+  const animateRoutes = () => {
+    if (!map || !map.getLayer(LAYER_ROUTES)) return;
+    const start = performance.now();
+    const duration = 800;
+    const step = (now: number) => {
+      if (!map?.getLayer(LAYER_ROUTES)) return;
+      const t = Math.min(1, (now - start) / duration);
+      map.setPaintProperty(LAYER_ROUTES, "line-opacity", 0.15 + t * 0.6);
+      if (t < 1) routeAnimFrame = requestAnimationFrame(step);
+    };
+    if (routeAnimFrame) cancelAnimationFrame(routeAnimFrame);
+    map.setPaintProperty(LAYER_ROUTES, "line-opacity", 0.15);
+    routeAnimFrame = requestAnimationFrame(step);
+  };
+
   /** Update source data in place — no marker teardown/rebuild churn. */
   const updateData = (pois: POI[], fit = true) => {
     if (!map) return;
@@ -225,6 +231,7 @@ const MapComponent = (_props: MapComponentProps) => {
     const { points, routes, valid } = buildData(pois);
     source.setData(points);
     (map.getSource(SOURCE_ROUTES) as mapboxgl.GeoJSONSource | undefined)?.setData(routes);
+    if (routes.features.length > 0) animateRoutes();
     if (fit) fitToData(valid);
     // Re-apply selection if the selected POI is still present.
     applySelection(props.selectedId);
@@ -316,7 +323,7 @@ const MapComponent = (_props: MapComponentProps) => {
         slot: SLOT,
         filter: ["has", "point_count"],
         paint: {
-          "circle-color": "#3b82f6",
+          "circle-color": LOCI_MAP_CLUSTER_COLOR,
           "circle-opacity": 0.85,
           "circle-stroke-width": 2,
           "circle-stroke-color": "#ffffff",
@@ -512,6 +519,7 @@ const MapComponent = (_props: MapComponentProps) => {
 
   onCleanup(() => {
     if (updateTimer) clearTimeout(updateTimer);
+    if (routeAnimFrame) cancelAnimationFrame(routeAnimFrame);
     popup?.remove();
     if (map) map.remove();
   });
@@ -521,7 +529,7 @@ const MapComponent = (_props: MapComponentProps) => {
       ref={mapContainer}
       role="application"
       aria-label="Itinerary map"
-      class="w-full h-full min-h-[300px] rounded-lg overflow-hidden"
+      class={`w-full h-full min-h-[300px] overflow-hidden ${props.fullBleed ? "" : "rounded-lg"}`}
     />
   );
 };

--- a/src/components/features/Settings/TasteAndPrivacy.tsx
+++ b/src/components/features/Settings/TasteAndPrivacy.tsx
@@ -1,0 +1,149 @@
+import { For, Show } from "solid-js";
+import { Brain, Database, Eye, RotateCcw, ShieldCheck } from "lucide-solid";
+import {
+  usePersonalizationSettings,
+  useResetTasteProfile,
+  useTasteProfile,
+  useUpdatePersonalizationSettings,
+} from "~/lib/api/recommendations";
+import { Button } from "~/ui/button";
+
+export default function TasteAndPrivacy() {
+  const settings = usePersonalizationSettings();
+  const taste = useTasteProfile();
+  const update = useUpdatePersonalizationSettings();
+  const reset = useResetTasteProfile();
+
+  const save = (key: "personalizationEnabled" | "contributeAggregate", value: boolean) => {
+    const current = settings.data;
+    if (!current) return;
+    update.mutate({
+      personalizationEnabled:
+        key === "personalizationEnabled" ? value : current.personalizationEnabled,
+      contributeAggregate: key === "contributeAggregate" ? value : current.contributeAggregate,
+      disclosureSeen: true,
+    });
+  };
+
+  return (
+    <section class="rounded-xl border border-border bg-card p-6 sm:p-8">
+      <div class="flex items-start gap-4">
+        <span class="grid h-11 w-11 shrink-0 place-items-center rounded-full bg-secondary text-secondary-foreground">
+          <Brain class="h-5 w-5" />
+        </span>
+        <div>
+          <p class="font-coord text-[10px] uppercase tracking-[0.18em] text-accent">
+            Your taste · your control
+          </p>
+          <h3 class="mt-1 text-2xl">How Loci learns</h3>
+          <p class="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Loci learns from places you keep, remove, visit, and rate. Search text and precise
+            location are not stored in recommendation traces.
+          </p>
+        </div>
+      </div>
+
+      <Show
+        when={settings.data}
+        fallback={<div class="mt-6 h-24 animate-pulse rounded-lg bg-muted" />}
+      >
+        {(current) => (
+          <div class="mt-7 grid gap-3">
+            <label class="flex cursor-pointer items-start justify-between gap-5 rounded-lg border border-border bg-background p-4">
+              <span class="flex gap-3">
+                <Eye class="mt-0.5 h-5 w-5 text-primary" />
+                <span>
+                  <span class="block text-sm font-semibold">Personalize my recommendations</span>
+                  <span class="mt-1 block text-xs leading-5 text-muted-foreground">
+                    Use your private taste profile to reorder places for you.
+                  </span>
+                </span>
+              </span>
+              <input
+                type="checkbox"
+                checked={current().personalizationEnabled}
+                onChange={(event) => save("personalizationEnabled", event.currentTarget.checked)}
+                class="h-5 w-5 accent-[hsl(var(--accent))]"
+              />
+            </label>
+            <label class="flex cursor-pointer items-start justify-between gap-5 rounded-lg border border-border bg-background p-4">
+              <span class="flex gap-3">
+                <Database class="mt-0.5 h-5 w-5 text-primary" />
+                <span>
+                  <span class="block text-sm font-semibold">Improve Loci for everyone</span>
+                  <span class="mt-1 block text-xs leading-5 text-muted-foreground">
+                    Include de-identified outcomes in aggregate quality measurement. This is
+                    separate from personal recommendations.
+                  </span>
+                </span>
+              </span>
+              <input
+                type="checkbox"
+                checked={current().contributeAggregate}
+                onChange={(event) => save("contributeAggregate", event.currentTarget.checked)}
+                class="h-5 w-5 accent-[hsl(var(--accent))]"
+              />
+            </label>
+          </div>
+        )}
+      </Show>
+
+      <div class="mt-8 border-t border-border pt-7">
+        <div class="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div class="flex items-center gap-2 text-sm font-semibold">
+              <ShieldCheck class="h-4 w-4 text-accent" />
+              Taste profile
+            </div>
+            <p class="mt-1 text-xs text-muted-foreground">
+              Based on {taste.data?.feedbackCount || 0} explicit outcomes ·{" "}
+              {taste.data?.algorithmVersion || "taste-v1"}
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            class="gap-2 text-destructive"
+            disabled={reset.isPending}
+            onClick={() => {
+              if (window.confirm("Delete your learned taste and recommendation history?"))
+                reset.mutate();
+            }}
+          >
+            <RotateCcw class="h-4 w-4" />
+            Reset learned taste
+          </Button>
+        </div>
+        <Show
+          when={taste.data?.traits?.length}
+          fallback={
+            <p class="mt-5 rounded-lg bg-muted p-4 text-sm text-muted-foreground">
+              Keep, remove, or rate a few places and your inspectable taste traits will appear here.
+            </p>
+          }
+        >
+          <div class="mt-5 grid gap-3 sm:grid-cols-2">
+            <For each={taste.data?.traits}>
+              {(trait) => (
+                <div class="rounded-lg border border-border bg-background p-4">
+                  <div class="flex items-center justify-between gap-3">
+                    <span class="text-sm font-semibold">{trait.label}</span>
+                    <span class="font-coord text-[9px] uppercase tracking-wider text-muted-foreground">
+                      {Math.round(trait.confidence * 100)}% sure
+                    </span>
+                  </div>
+                  <div class="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
+                    <div
+                      class="h-full rounded-full bg-accent"
+                      style={{ width: `${Math.max(4, Math.abs(trait.score) * 100)}%` }}
+                    />
+                  </div>
+                  <p class="mt-2 text-xs text-muted-foreground">{trait.evidenceCount} signals</p>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </section>
+  );
+}

--- a/src/components/layout/SplitView.tsx
+++ b/src/components/layout/SplitView.tsx
@@ -7,19 +7,20 @@ interface SplitViewProps {
   initialMode?: "split" | "list" | "map";
 }
 
+const toggleActive = "bg-primary text-primary-foreground shadow-sm";
+const toggleIdle = "text-muted-foreground hover:bg-muted hover:text-foreground";
+
 export default function SplitView(props: SplitViewProps) {
   const [mode, setMode] = createSignal<"split" | "list" | "map">(props.initialMode || "split");
 
   return (
-    <div class="flex flex-col h-[calc(100vh-4rem)] overflow-hidden bg-transparent">
+    <div class="flex flex-col h-[calc(100vh-4rem)] overflow-hidden bg-background">
       {/* Mobile Toggle Controls */}
-      <div class="flex items-center justify-center p-2 gap-2 md:hidden bg-white/80 dark:bg-slate-900/80 backdrop-blur-md border-b border-gray-200 dark:border-gray-800 z-10 sticky top-0">
+      <div class="flex items-center justify-center p-2 gap-2 md:hidden island-panel border-b border-border z-10 sticky top-0">
         <button
           onClick={() => setMode("list")}
-          class={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-            mode() === "list"
-              ? "bg-blue-600 text-white shadow-md shadow-blue-500/20"
-              : "text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+          class={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium motion-settle min-h-[44px] ${
+            mode() === "list" ? toggleActive : toggleIdle
           }`}
         >
           <List class="w-4 h-4" />
@@ -27,10 +28,8 @@ export default function SplitView(props: SplitViewProps) {
         </button>
         <button
           onClick={() => setMode("map")}
-          class={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-            mode() === "map"
-              ? "bg-blue-600 text-white shadow-md shadow-blue-500/20"
-              : "text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+          class={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium motion-settle min-h-[44px] ${
+            mode() === "map" ? toggleActive : toggleIdle
           }`}
         >
           <Map class="w-4 h-4" />
@@ -39,13 +38,11 @@ export default function SplitView(props: SplitViewProps) {
       </div>
 
       {/* Desktop Toggle Controls (Top Right Overlay) */}
-      <div class="hidden md:flex absolute top-20 right-4 z-20 bg-white/90 dark:bg-slate-900/90 backdrop-blur-md border border-gray-200 dark:border-gray-700 rounded-lg p-1 shadow-lg">
+      <div class="hidden md:flex absolute top-20 right-4 z-20 island-panel rounded-lg p-1">
         <button
           onClick={() => setMode("list")}
-          class={`p-2 rounded-md transition-colors ${
-            mode() === "list"
-              ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
-              : "text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+          class={`p-2 rounded-md motion-settle min-h-[44px] min-w-[44px] flex items-center justify-center ${
+            mode() === "list" ? "bg-secondary text-foreground" : toggleIdle
           }`}
           title="List Only"
         >
@@ -53,10 +50,8 @@ export default function SplitView(props: SplitViewProps) {
         </button>
         <button
           onClick={() => setMode("split")}
-          class={`p-2 rounded-md transition-colors ${
-            mode() === "split"
-              ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
-              : "text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+          class={`p-2 rounded-md motion-settle min-h-[44px] min-w-[44px] flex items-center justify-center ${
+            mode() === "split" ? "bg-secondary text-foreground" : toggleIdle
           }`}
           title="Split View"
         >
@@ -64,10 +59,8 @@ export default function SplitView(props: SplitViewProps) {
         </button>
         <button
           onClick={() => setMode("map")}
-          class={`p-2 rounded-md transition-colors ${
-            mode() === "map"
-              ? "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
-              : "text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+          class={`p-2 rounded-md motion-settle min-h-[44px] min-w-[44px] flex items-center justify-center ${
+            mode() === "map" ? "bg-secondary text-foreground" : toggleIdle
           }`}
           title="Map Only"
         >
@@ -78,20 +71,20 @@ export default function SplitView(props: SplitViewProps) {
       <div class="flex-1 flex overflow-hidden relative">
         {/* List Panel */}
         <div
-          class={`flex-1 h-full overflow-y-auto transition-all duration-300 ease-in-out ${
+          class={`flex-1 h-full overflow-y-auto motion-settle ${
             mode() === "map"
               ? "hidden w-0"
               : mode() === "split"
-                ? "w-1/2 md:max-w-[600px] border-r border-gray-200/50 dark:border-gray-800/50"
+                ? "w-1/2 md:max-w-[600px] border-r border-border"
                 : "w-full"
-          } bg-transparent`}
+          } bg-background`}
         >
           <div class="h-full relative z-0">{props.listContent}</div>
         </div>
 
         {/* Map Panel */}
         <div
-          class={`flex-1 h-full transition-all duration-300 ease-in-out relative z-0 ${
+          class={`flex-1 h-full motion-settle relative z-0 ${
             mode() === "list" ? "hidden w-0" : mode() === "split" ? "w-1/2" : "w-full"
           }`}
         >

--- a/src/components/lists/AddToListButton.tsx
+++ b/src/components/lists/AddToListButton.tsx
@@ -2,6 +2,7 @@ import { createSignal, Show, For } from "solid-js";
 import { Plus, FolderPlus, X } from "lucide-solid";
 import { useLists, useCreateListMutation } from "~/lib/api/lists";
 import { useAddToListMutation } from "~/lib/api/lists";
+import type { RecommendationTrace } from "~/lib/api/recommendations";
 
 interface AddToListButtonProps {
   itemId: string;
@@ -12,6 +13,7 @@ interface AddToListButtonProps {
   variant?: "icon" | "button" | "minimal";
   sourceInteractionId?: string;
   aiDescription?: string;
+  recommendationTrace?: RecommendationTrace;
 }
 
 export default function AddToListButton(props: AddToListButtonProps) {
@@ -58,6 +60,7 @@ export default function AddToListButton(props: AddToListButtonProps) {
           contentType: props.contentType,
           position: 0, // Will be set by backend
           notes: "",
+          recommendationTrace: props.recommendationTrace,
         },
       });
       setShowListModal(false);

--- a/src/components/poi/WhyThisStop.tsx
+++ b/src/components/poi/WhyThisStop.tsx
@@ -12,10 +12,7 @@ export default function WhyThisStop(props: WhyThisStopProps) {
   const text = () => props.reason?.trim() ?? "";
   return (
     <Show when={text()}>
-      <p
-        class={`mt-1.5 inline-flex max-w-full items-start gap-1.5 rounded-md border border-primary/20 bg-primary/5 px-2 py-1 text-xs text-foreground/80 ${props.class ?? ""}`}
-        title="Why Loci suggested this"
-      >
+      <p class={`trust-chip mt-1.5 ${props.class ?? ""}`} title="Why Loci suggested this">
         <Sparkles class="mt-0.5 h-3 w-3 shrink-0 text-primary" aria-hidden="true" />
         <span class="min-w-0">
           <span class="font-medium text-primary">Why this: </span>

--- a/src/components/results/HotelResults.tsx
+++ b/src/components/results/HotelResults.tsx
@@ -89,9 +89,7 @@ export default function HotelResults(props: HotelResultsProps) {
         <div class="w-6 h-6 rounded-full bg-primary flex items-center justify-center text-primary-foreground text-xs">
           🏨
         </div>
-        <h3 class="font-semibold text-foreground">
-          Hotels ({displayHotels().length})
-        </h3>
+        <h3 class="font-semibold text-foreground">Hotels ({displayHotels().length})</h3>
       </div>
 
       <div class={props.compact ? "space-y-2" : "space-y-4"}>
@@ -138,9 +136,7 @@ export default function HotelResults(props: HotelResultsProps) {
               </div>
 
               <Show when={hotel.description && !props.compact}>
-                <p class="text-sm text-muted-foreground mb-3 line-clamp-2">
-                  {hotel.description}
-                </p>
+                <p class="text-sm text-muted-foreground mb-3 line-clamp-2">{hotel.description}</p>
               </Show>
 
               <div class="flex items-center gap-4 text-xs text-muted-foreground">
@@ -185,6 +181,8 @@ export default function HotelResults(props: HotelResultsProps) {
                       description: hotel.description || "",
                     }}
                     size="sm"
+                    recommendationTrace={hotel.recommendation_trace}
+                    poiId={hotel.id}
                   />
                   <Show when={props.onShareClick}>
                     <button

--- a/src/components/results/ItineraryResults.tsx
+++ b/src/components/results/ItineraryResults.tsx
@@ -255,6 +255,8 @@ export default function ItineraryResults(props: ItineraryResultsProps) {
                           llmInteractionId: poi.llm_interaction_id,
                         }}
                         size="sm"
+                        recommendationTrace={poi.recommendation_trace}
+                        poiId={poi.id}
                       />
 
                       {/* Share Button */}

--- a/src/components/results/RestaurantResults.tsx
+++ b/src/components/results/RestaurantResults.tsx
@@ -91,9 +91,7 @@ export default function RestaurantResults(props: RestaurantResultsProps) {
         <div class="w-6 h-6 rounded-full bg-accent flex items-center justify-center text-accent-foreground text-xs">
           🍽️
         </div>
-        <h3 class="font-semibold text-foreground">
-          Restaurants ({displayRestaurants().length})
-        </h3>
+        <h3 class="font-semibold text-foreground">Restaurants ({displayRestaurants().length})</h3>
       </div>
 
       <div class={props.compact ? "space-y-2" : "space-y-4"}>
@@ -189,6 +187,8 @@ export default function RestaurantResults(props: RestaurantResultsProps) {
                       llmInteractionId: restaurant.llm_interaction_id,
                     }}
                     size="sm"
+                    recommendationTrace={restaurant.recommendation_trace}
+                    poiId={restaurant.id}
                   />
 
                   {/* Add to List Button */}
@@ -200,6 +200,7 @@ export default function RestaurantResults(props: RestaurantResultsProps) {
                     size="md"
                     sourceInteractionId={restaurant.llm_interaction_id}
                     aiDescription={restaurant.description}
+                    recommendationTrace={restaurant.recommendation_trace}
                   />
                   <Show when={props.onShareClick}>
                     <button

--- a/src/components/shared/FavoriteButton.tsx
+++ b/src/components/shared/FavoriteButton.tsx
@@ -1,6 +1,7 @@
 import { Component, createMemo, Show } from "solid-js";
 import { Heart, Loader2 } from "lucide-solid";
 import { useFavoritesList, useToggleFavorite, type FavoriteItem } from "~/lib/api/favorites";
+import { recordRecommendationEvents, type RecommendationTrace } from "~/lib/api/recommendations";
 
 interface FavoriteButtonProps {
   item: FavoriteItem;
@@ -8,6 +9,8 @@ interface FavoriteButtonProps {
   className?: string;
   showLabel?: boolean;
   onClick?: (e: Event) => void;
+  recommendationTrace?: RecommendationTrace;
+  poiId?: string;
 }
 
 const FavoriteButton: Component<FavoriteButtonProps> = (props) => {
@@ -50,7 +53,17 @@ const FavoriteButton: Component<FavoriteButtonProps> = (props) => {
       props.onClick(e);
       return;
     }
+    const wasFavorited = isFavorited();
     await toggleFavorite(props.item);
+    if (!wasFavorited && props.recommendationTrace) {
+      void recordRecommendationEvents([
+        {
+          eventType: "RECOMMENDATION_EVENT_TYPE_FAVORITED",
+          trace: props.recommendationTrace,
+          poiId: props.poiId || props.item.id,
+        },
+      ]);
+    }
   };
 
   return (

--- a/src/components/trip/AddToTripButton.tsx
+++ b/src/components/trip/AddToTripButton.tsx
@@ -1,0 +1,152 @@
+import { createEffect, createSignal, For, Show } from "solid-js";
+import { A } from "@solidjs/router";
+import { CalendarPlus, Check } from "lucide-solid";
+import { useAddStop, useTrips } from "~/lib/api/trips";
+import type { POI } from "~/lib/api/types";
+
+interface AddToTripButtonProps {
+  poi: POI;
+}
+
+export default function AddToTripButton(props: AddToTripButtonProps) {
+  const tripsQuery = useTrips();
+  const addStop = useAddStop();
+  const [open, setOpen] = createSignal(false);
+  const [tripID, setTripID] = createSignal("");
+  const [dayID, setDayID] = createSignal("");
+  const [message, setMessage] = createSignal<string | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const trips = () => tripsQuery.data ?? [];
+  const selectedTrip = () => trips().find((trip) => trip.id === tripID());
+
+  createEffect(() => {
+    if (!tripID() && trips().length > 0) setTripID(trips()[0].id);
+  });
+
+  createEffect(() => {
+    const trip = selectedTrip();
+    if (trip && !trip.days.some((day) => day.id === dayID())) setDayID(trip.days[0]?.id ?? "");
+  });
+
+  const add = () => {
+    const trip = selectedTrip();
+    const day = trip?.days.find((candidate) => candidate.id === dayID());
+    if (!trip || !day) return;
+    setError(null);
+    setMessage(null);
+    addStop.mutate(
+      {
+        tripId: trip.id,
+        dayId: day.id,
+        baseVersion: trip.version,
+        stop: {
+          id: crypto.randomUUID(),
+          poiId: props.poi.id,
+          orderIndex: day.stops.length,
+          name: props.poi.name,
+          notes:
+            props.poi.recommendation_rationale ||
+            props.poi.description_poi ||
+            "Added from Discover",
+          recommendationTrace: props.poi.recommendation_trace,
+        },
+      },
+      {
+        onSuccess: () => {
+          setMessage(`Added to Day ${day.dayNumber}`);
+          setOpen(false);
+        },
+        onError: () => setError("We couldn't add this place. Refresh the trip and try again."),
+      },
+    );
+  };
+
+  return (
+    <div class="relative">
+      <button
+        type="button"
+        class="inline-flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2.5 py-1.5 text-xs font-medium text-primary transition-all hover:-translate-y-px hover:bg-primary/10 active:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        onClick={() => {
+          setOpen((value) => !value);
+          setMessage(null);
+          setError(null);
+        }}
+        aria-expanded={open()}
+      >
+        <CalendarPlus class="h-3.5 w-3.5" />
+        Add to trip
+      </button>
+      <Show when={message()}>
+        <span class="ml-2 inline-flex items-center gap-1 text-xs font-medium text-primary">
+          <Check class="h-3.5 w-3.5" /> {message()}
+        </span>
+      </Show>
+
+      <Show when={open()}>
+        <div class="absolute bottom-full left-0 z-30 mb-2 w-[min(20rem,calc(100vw-2rem))] rounded-xl border border-border bg-popover p-3 text-popover-foreground shadow-xl">
+          <p class="text-sm font-semibold">Add {props.poi.name}</p>
+          <Show
+            when={!tripsQuery.isLoading}
+            fallback={<div class="mt-3 h-20 animate-pulse rounded-lg bg-muted" />}
+          >
+            <Show
+              when={trips().length > 0}
+              fallback={
+                <div class="mt-3 rounded-lg bg-muted/60 p-3 text-sm text-muted-foreground">
+                  <p>Create a trip first, then bring this place along.</p>
+                  <A
+                    href="/trips"
+                    class="mt-2 inline-block font-medium text-primary hover:underline"
+                  >
+                    Open trips
+                  </A>
+                </div>
+              }
+            >
+              <div class="mt-3 grid gap-2 sm:grid-cols-2">
+                <label class="text-xs font-medium text-muted-foreground">
+                  Trip
+                  <select
+                    class="mt-1 h-9 w-full rounded-lg border border-input bg-background px-2 text-sm text-foreground"
+                    value={tripID()}
+                    onChange={(event) => setTripID(event.currentTarget.value)}
+                  >
+                    <For each={trips()}>
+                      {(trip) => <option value={trip.id}>{trip.title}</option>}
+                    </For>
+                  </select>
+                </label>
+                <label class="text-xs font-medium text-muted-foreground">
+                  Day
+                  <select
+                    class="mt-1 h-9 w-full rounded-lg border border-input bg-background px-2 text-sm text-foreground"
+                    value={dayID()}
+                    onChange={(event) => setDayID(event.currentTarget.value)}
+                  >
+                    <For each={selectedTrip()?.days ?? []}>
+                      {(day) => <option value={day.id}>Day {day.dayNumber}</option>}
+                    </For>
+                  </select>
+                </label>
+              </div>
+              <button
+                type="button"
+                class="mt-3 w-full rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground transition-transform hover:opacity-90 active:scale-[0.99] disabled:opacity-50"
+                disabled={!dayID() || addStop.isPending}
+                onClick={add}
+              >
+                {addStop.isPending ? "Adding…" : "Add to this day"}
+              </button>
+            </Show>
+          </Show>
+          <Show when={error()}>
+            <p class="mt-2 text-xs text-destructive" role="alert">
+              {error()}
+            </p>
+          </Show>
+        </div>
+      </Show>
+    </div>
+  );
+}

--- a/src/components/trip/PlacePicker.tsx
+++ b/src/components/trip/PlacePicker.tsx
@@ -1,0 +1,118 @@
+import { createSignal, For, Show } from "solid-js";
+import { MapPin, Search } from "lucide-solid";
+import { searchPOIs } from "~/lib/api/pois";
+import type { POI } from "~/lib/api/types";
+
+interface PlacePickerProps {
+  cityName?: string;
+  label: string;
+  busy?: boolean;
+  onSelect: (poi: POI) => void;
+  onCancel?: () => void;
+}
+
+export default function PlacePicker(props: PlacePickerProps) {
+  const [query, setQuery] = createSignal("");
+  const [results, setResults] = createSignal<POI[]>([]);
+  const [searching, setSearching] = createSignal(false);
+  const [searched, setSearched] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const submit = async (event: Event) => {
+    event.preventDefault();
+    const value = query().trim();
+    if (!value || searching()) return;
+    setSearching(true);
+    setSearched(true);
+    setError(null);
+    try {
+      setResults((await searchPOIs(value, { cityName: props.cityName })).slice(0, 6));
+    } catch {
+      setResults([]);
+      setError("We couldn't search places. Try again.");
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  return (
+    <div class="rounded-xl border border-border/70 bg-card/80 p-3 shadow-sm">
+      <div class="mb-2 flex items-center justify-between gap-3">
+        <div>
+          <p class="text-sm font-semibold text-foreground">{props.label}</p>
+          <Show when={props.cityName}>
+            <p class="text-xs text-muted-foreground">Search canonical places in {props.cityName}</p>
+          </Show>
+        </div>
+        <Show when={props.onCancel}>
+          <button
+            type="button"
+            class="rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => props.onCancel?.()}
+          >
+            Cancel
+          </button>
+        </Show>
+      </div>
+
+      <form class="flex gap-2" onSubmit={submit}>
+        <label class="relative min-w-0 flex-1">
+          <span class="sr-only">Search for a place</span>
+          <Search class="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <input
+            class="h-10 w-full rounded-lg border border-input bg-background pl-9 pr-3 text-sm outline-none transition-shadow focus-visible:ring-2 focus-visible:ring-ring"
+            value={query()}
+            onInput={(event) => setQuery(event.currentTarget.value)}
+            placeholder="Museum, market, viewpoint…"
+            autocomplete="off"
+          />
+        </label>
+        <button
+          type="submit"
+          class="h-10 rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground transition-transform hover:opacity-90 active:scale-[0.98] disabled:opacity-50"
+          disabled={!query().trim() || searching() || props.busy}
+        >
+          {searching() ? "Searching…" : "Search"}
+        </button>
+      </form>
+
+      <Show when={error()}>
+        <p class="mt-2 text-sm text-destructive" role="alert">
+          {error()}
+        </p>
+      </Show>
+      <Show when={searched() && !searching() && !error() && results().length === 0}>
+        <p class="mt-3 rounded-lg bg-muted/60 px-3 py-2 text-sm text-muted-foreground">
+          No matching places yet. Try a landmark name or broader category.
+        </p>
+      </Show>
+      <Show when={results().length > 0}>
+        <ul class="mt-3 divide-y divide-border/60 overflow-hidden rounded-lg border border-border/60">
+          <For each={results()}>
+            {(poi) => (
+              <li>
+                <button
+                  type="button"
+                  class="flex w-full items-start gap-3 bg-background/70 px-3 py-2.5 text-left transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring disabled:opacity-50"
+                  disabled={props.busy}
+                  onClick={() => props.onSelect(poi)}
+                >
+                  <MapPin class="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+                  <span class="min-w-0 flex-1">
+                    <span class="block truncate text-sm font-medium text-foreground">
+                      {poi.name}
+                    </span>
+                    <span class="block truncate text-xs text-muted-foreground">
+                      {[poi.category, poi.address || poi.city].filter(Boolean).join(" · ")}
+                    </span>
+                  </span>
+                  <span class="text-xs font-medium text-primary">Choose</span>
+                </button>
+              </li>
+            )}
+          </For>
+        </ul>
+      </Show>
+    </div>
+  );
+}

--- a/src/components/trip/TripExportMenu.tsx
+++ b/src/components/trip/TripExportMenu.tsx
@@ -34,7 +34,7 @@ export default function TripExportMenu(props: TripExportMenuProps) {
     }
     setBusy("ics");
     try {
-      await exportTripICS(props.tripId);
+      await exportTripICS(props.tripId, props.trip);
       flash(
         props.isPro || props.dayCount <= 1
           ? "Calendar downloaded."
@@ -55,7 +55,7 @@ export default function TripExportMenu(props: TripExportMenuProps) {
     }
     setBusy("pdf");
     try {
-      await exportTripPDF(props.tripId);
+      await exportTripPDF(props.tripId, props.trip);
       flash("PDF downloaded.");
     } catch (e) {
       flash(e instanceof Error ? e.message : "PDF export failed");
@@ -71,7 +71,7 @@ export default function TripExportMenu(props: TripExportMenuProps) {
     }
     setBusy("md");
     try {
-      await exportTripMarkdown(props.tripId);
+      await exportTripMarkdown(props.tripId, props.trip);
       flash("Markdown downloaded.");
     } catch (e) {
       if (handleEntitlementError(e)) {

--- a/src/components/ui/ChatInterface.tsx
+++ b/src/components/ui/ChatInterface.tsx
@@ -1,21 +1,16 @@
 import { For, Show, Component } from "solid-js";
-import { MessageCircle, Send, X, Loader2 } from "lucide-solid";
+import { Bot, Loader2, MessageCircle, Send, User, X } from "lucide-solid";
 import type { ChatMessage } from "~/lib/hooks/useChatSession";
 
 export interface ChatInterfaceProps {
-  // State
   showChat: boolean;
   chatMessage: string;
   chatHistory: ChatMessage[];
   isLoading: boolean;
-
-  // Actions
   setShowChat: (show: boolean) => void;
   setChatMessage: (message: string) => void;
   sendChatMessage: () => void;
   handleKeyPress: (e: KeyboardEvent) => void;
-
-  // Configuration
   title?: string;
   placeholder?: string;
   emptyStateIcon?: Component;
@@ -25,65 +20,90 @@ export interface ChatInterfaceProps {
 }
 
 export default function ChatInterface(props: ChatInterfaceProps) {
-  const title = () => props.title || "Chat Assistant";
-  const placeholder = () => props.placeholder || "Ask me something...";
-  const emptyStateTitle = () => props.emptyStateTitle || "Start a conversation!";
-  const emptyStateSubtitle = () => props.emptyStateSubtitle || "Ask me anything to get started.";
-  const loadingMessage = () => props.loadingMessage || "Processing your request...";
+  const title = () => props.title || "Ask Loci";
+  const placeholder = () => props.placeholder || "Ask about your trip…";
+  const emptyStateTitle = () => props.emptyStateTitle || "Start a field note";
+  const emptyStateSubtitle = () =>
+    props.emptyStateSubtitle || "Ask for places, routes, or a day plan.";
+  const loadingMessage = () => props.loadingMessage || "Thinking…";
 
   const EmptyIcon = props.emptyStateIcon || MessageCircle;
 
   return (
     <>
-      {/* Chat Interface */}
+      <Show when={!props.showChat}>
+        <button
+          onClick={() => props.setShowChat(true)}
+          class="fixed bottom-6 right-6 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg motion-settle motion-press hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          aria-label="Open Ask Loci"
+        >
+          <MessageCircle class="h-6 w-6" />
+        </button>
+      </Show>
+
       <Show when={props.showChat}>
         <div
-          class="fixed bottom-6 right-6 w-96 h-[500px] bg-card text-foreground rounded-lg shadow-2xl border border-border flex flex-col z-50 focus:outline-none"
+          class="fixed bottom-6 right-6 z-50 flex h-[min(560px,calc(100vh-6rem))] w-[min(24rem,calc(100vw-2rem))] flex-col island-panel rounded-xl focus:outline-none"
           role="dialog"
           aria-modal="true"
           aria-label={title()}
           tabIndex={-1}
         >
-          {/* Chat Header */}
-          <div class="flex items-center justify-between p-4 border-b border-border bg-primary text-primary-foreground rounded-t-lg">
+          <div class="flex items-center justify-between border-b border-border px-4 py-3">
             <div class="flex items-center gap-2">
-              <MessageCircle class="w-5 h-5" />
-              <span class="font-medium">{title()}</span>
+              <span class="flex h-8 w-8 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                <Bot class="h-4 w-4" />
+              </span>
+              <div>
+                <span class="block font-serif text-sm font-semibold leading-tight">{title()}</span>
+                <span class="font-coord text-[10px] uppercase tracking-widest text-muted-foreground">
+                  Field guide
+                </span>
+              </div>
             </div>
             <button
               onClick={() => props.setShowChat(false)}
-              class="p-1 hover:bg-primary-foreground/20 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary-foreground/70"
+              class="rounded-md p-2 text-muted-foreground hover:bg-muted hover:text-foreground motion-settle min-h-[44px] min-w-[44px] flex items-center justify-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               aria-label="Close chat"
             >
-              <X class="w-4 h-4" />
+              <X class="h-4 w-4" />
             </button>
           </div>
 
-          {/* Chat Messages */}
           <div class="flex-1 overflow-y-auto p-4 space-y-4" role="log" aria-live="polite">
             <Show when={props.chatHistory.length === 0}>
-              <div class="text-center text-muted-foreground py-8">
-                <EmptyIcon class="w-12 h-12 mx-auto mb-4 text-muted-foreground/50" aria-hidden="true" />
-                <p class="text-sm font-medium">{emptyStateTitle()}</p>
-                <p class="text-xs mt-2 text-muted-foreground">{emptyStateSubtitle()}</p>
+              <div class="py-8 text-center text-muted-foreground">
+                <EmptyIcon
+                  class="mx-auto mb-4 h-10 w-10 text-muted-foreground/50"
+                  aria-hidden="true"
+                />
+                <p class="font-serif text-sm font-medium text-foreground">{emptyStateTitle()}</p>
+                <p class="mt-2 text-xs">{emptyStateSubtitle()}</p>
               </div>
             </Show>
 
             <For each={props.chatHistory}>
               {(message) => (
-                <div class={`flex ${message.type === "user" ? "justify-end" : "justify-start"}`}>
+                <div
+                  class={`flex gap-2 ${message.type === "user" ? "justify-end" : "justify-start"}`}
+                >
+                  <Show when={message.type !== "user"}>
+                    <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                      <Bot class="h-3.5 w-3.5" />
+                    </div>
+                  </Show>
                   <div
-                    class={`max-w-[80%] p-3 rounded-lg text-sm ${
+                    class={`max-w-[85%] rounded-2xl px-3 py-2 text-sm motion-enter ${
                       message.type === "user"
                         ? "bg-primary text-primary-foreground"
                         : message.type === "error"
-                          ? "bg-destructive/10 text-destructive border border-destructive/30"
-                          : "bg-muted text-foreground"
+                          ? "border border-destructive/30 bg-destructive/10 text-destructive"
+                          : "loci-card"
                     }`}
                   >
                     <p class="whitespace-pre-wrap">{message.content}</p>
                     <p
-                      class={`text-xs mt-1 opacity-70 ${
+                      class={`mt-1 font-coord text-[10px] uppercase tracking-wide opacity-70 ${
                         message.type === "user"
                           ? "text-primary-foreground/70"
                           : "text-muted-foreground"
@@ -95,58 +115,45 @@ export default function ChatInterface(props: ChatInterfaceProps) {
                       })}
                     </p>
                   </div>
+                  <Show when={message.type === "user"}>
+                    <div class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
+                      <User class="h-3.5 w-3.5 text-muted-foreground" />
+                    </div>
+                  </Show>
                 </div>
               )}
             </For>
 
             <Show when={props.isLoading}>
-              <div class="flex justify-start" aria-live="assertive">
-                <div class="bg-muted p-3 rounded-lg flex items-center gap-2 text-sm text-muted-foreground">
-                  <Loader2 class="w-4 h-4 animate-spin" />
-                  <span>{loadingMessage()}</span>
-                </div>
+              <div class="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 class="h-4 w-4 animate-spin" />
+                {loadingMessage()}
               </div>
             </Show>
           </div>
 
-          {/* Chat Input */}
-          <div class="p-4 border-t border-border">
+          <div class="border-t border-border p-3">
             <div class="flex items-end gap-2">
               <textarea
                 value={props.chatMessage}
-                onInput={(e) => props.setChatMessage(e.target.value)}
+                onInput={(e) => props.setChatMessage(e.currentTarget.value)}
                 onKeyPress={props.handleKeyPress}
                 placeholder={placeholder()}
-                aria-label={placeholder()}
-                class="flex-1 resize-none border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent bg-background text-foreground placeholder:text-muted-foreground"
-                rows="2"
                 disabled={props.isLoading}
+                rows={2}
+                class="min-h-[52px] max-h-32 flex-1 resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               />
               <button
                 onClick={props.sendChatMessage}
                 disabled={!props.chatMessage.trim() || props.isLoading}
-                class="p-2 bg-primary text-primary-foreground rounded-lg hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
+                class="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground motion-settle motion-press disabled:opacity-50"
                 aria-label="Send message"
-                aria-disabled={!props.chatMessage.trim() || props.isLoading}
               >
-                <Send class="w-4 h-4" />
+                <Send class="h-4 w-4" />
               </button>
             </div>
           </div>
         </div>
-      </Show>
-
-      {/* Floating Chat Button */}
-      <Show when={!props.showChat}>
-        <button
-          onClick={() => props.setShowChat(true)}
-          class="fixed bottom-4 right-4 w-12 h-12 bg-primary hover:opacity-90 text-primary-foreground rounded-full shadow-lg transition-all hover:scale-105 flex items-center justify-center z-40 sm:bottom-6 sm:right-6 sm:w-14 sm:h-14 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-ring"
-          aria-label="Open chat to continue planning"
-          aria-expanded={props.showChat}
-          aria-haspopup="dialog"
-        >
-          <MessageCircle class="w-5 h-5 sm:w-6 sm:h-6" />
-        </button>
       </Show>
     </>
   );

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -34,7 +34,7 @@ interface ThemeProviderProps {
   children: JSX.Element;
 }
 
-const applyToDocument = (isDark: boolean, design: DesignTheme) => {
+const applyToDocument = (isDark: boolean, _design: DesignTheme) => {
   const html = document.documentElement;
   const body = document.body;
 
@@ -50,12 +50,12 @@ const applyToDocument = (isDark: boolean, design: DesignTheme) => {
     html.setAttribute("data-kb-theme", "light");
   }
 
-  html.setAttribute("data-theme", design);
+  html.setAttribute("data-theme", "loci");
 };
 
 const persistLocalThemePreference = (pref: ThemePreference) => {
   localStorage.setItem("theme", pref.color);
-  localStorage.setItem("designTheme", pref.design);
+  localStorage.setItem("designTheme", "loci");
 };
 
 export const ThemeProvider = (props: ThemeProviderProps) => {
@@ -73,7 +73,7 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
     options: { persistLocal?: boolean } = {},
   ) => {
     setColorMode(pref.color);
-    setDesignThemeSignal(pref.design);
+    setDesignThemeSignal("loci");
     syncResolvedDark(pref.color);
 
     if (options.persistLocal !== false) {
@@ -92,12 +92,11 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
       applyThemePreference(savedPreference, { persistLocal: false });
     } else {
       const saved = localStorage.getItem("theme");
-      const savedDesignTheme = (localStorage.getItem("designTheme") as DesignTheme) || "loci";
       const mode: ColorTheme =
         saved === "dark" || saved === "light" || saved === "system" ? saved : "system";
 
       setColorMode(mode);
-      setDesignThemeSignal(savedDesignTheme);
+      setDesignThemeSignal("loci");
       syncResolvedDark(mode);
     }
 
@@ -130,7 +129,8 @@ export const ThemeProvider = (props: ThemeProviderProps) => {
   };
 
   const setDesignTheme = (theme: DesignTheme) => {
-    applyThemePreference({ design: theme, color: colorMode() });
+    void theme;
+    applyThemePreference({ design: "loci", color: colorMode() });
   };
 
   const themeValue: ThemeContextType = {

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -16,10 +16,10 @@ export default createHandler(() => (
           <link
             rel="preload"
             as="style"
-            href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&family=Space+Grotesk:wght@300..700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400..700&family=Fraunces:opsz,wght@9..144,500..700&family=Space+Mono:wght@400;700&display=swap"
           />
           <link
-            href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&family=Space+Grotesk:wght@300..700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400..700&family=Fraunces:opsz,wght@9..144,500..700&family=Space+Mono:wght@400;700&display=swap"
             rel="stylesheet"
             media="print"
             onLoad={(e) => {
@@ -28,7 +28,7 @@ export default createHandler(() => (
           />
           <noscript>
             <link
-              href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&family=Space+Grotesk:wght@300..700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+              href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400..700&family=Fraunces:opsz,wght@9..144,500..700&family=Space+Mono:wght@400;700&display=swap"
               rel="stylesheet"
             />
           </noscript>
@@ -111,16 +111,9 @@ export default createHandler(() => (
                     document.documentElement.lang = localLanguage;
                   }
                   
-                  var designTheme = localStorage.getItem('designTheme') || 'loci';
-                  document.documentElement.setAttribute('data-theme', designTheme);
-
-                  var palette = {
-                    loci: { light: '#1a1a1a', dark: '#0a0a0a' },
-                    classic: { light: '#8a6e2f', dark: '#5c4033' },
-                    modern: { light: '#0c7df2', dark: '#1e3a8a' }
-                  };
-                  var colors = palette[designTheme] || palette.loci;
-                  var themeColor = useDark ? colors.dark : colors.light;
+                  document.documentElement.setAttribute('data-theme', 'loci');
+                  localStorage.setItem('designTheme', 'loci');
+                  var themeColor = useDark ? '#14251e' : '#294d3c';
                   var themeMeta = document.querySelector('meta[name="theme-color"]');
                   if (themeMeta) themeMeta.setAttribute('content', themeColor);
                 } catch (e) {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -73,6 +73,9 @@ describe("Auth API", () => {
         access_token: "fake-access-token",
         refresh_token: "fake-refresh-token",
         message: "Login successful",
+        user_id: "",
+        username: "",
+        email: "test@example.com",
       });
     });
 

--- a/src/lib/api/lists.ts
+++ b/src/lib/api/lists.ts
@@ -16,6 +16,11 @@ import { create } from "@bufbuild/protobuf";
 import { transport } from "../connect-transport";
 import { getAuthToken, authAPI } from "../api";
 import { handleEntitlementError } from "../entitlement-error";
+import {
+  recordRecommendationEvents,
+  toProtoRecommendationTrace,
+  type RecommendationTrace,
+} from "./recommendations";
 
 const listClient = createClient(ListService, transport);
 
@@ -236,6 +241,7 @@ export interface AddListItemData {
   dayNumber?: number;
   durationMinutes?: number;
   itemAiDescription?: string;
+  recommendationTrace?: RecommendationTrace;
 }
 
 export const useAddToListMutation = () => {
@@ -257,13 +263,24 @@ export const useAddToListMutation = () => {
             notes: itemData.notes || "",
             dayNumber: itemData.dayNumber || 0,
             durationMinutes: itemData.durationMinutes || 0,
+            recommendationTrace: toProtoRecommendationTrace(itemData.recommendationTrace),
           }),
         );
         return response;
       }),
-    onSuccess: (_, { listId }) => {
+    onSuccess: (_, { listId, itemData }) => {
       queryClient.invalidateQueries({ queryKey: ["list", listId] });
       queryClient.invalidateQueries({ queryKey: ["lists"] });
+      if (itemData.recommendationTrace) {
+        void recordRecommendationEvents([
+          {
+            eventType: "RECOMMENDATION_EVENT_TYPE_ADDED_TO_LIST",
+            trace: itemData.recommendationTrace,
+            poiId: itemData.itemId,
+            metadata: { list_id: listId },
+          },
+        ]);
+      }
     },
   }));
 };

--- a/src/lib/api/llm.test.ts
+++ b/src/lib/api/llm.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
-import { detectDomain, toProtoDomainType, domainToContextType } from "./llm";
+import { create } from "@bufbuild/protobuf";
+import { POIDetailedInfoSchema } from "@buf/loci_loci-proto.bufbuild_es/loci/poi/poi_pb.js";
+import {
+  RecommendationChannel,
+  RecommendationSurface,
+  RecommendationTraceSchema,
+} from "@buf/loci_loci-proto.bufbuild_es/loci/recommendation/recommendation_pb.js";
+import { detectDomain, toProtoDomainType, domainToContextType, mapPoi } from "./llm";
 
 // Mock the proto module since it may not be available in test environment
 vi.mock("@buf/loci_loci-proto.bufbuild_es/proto/locichat_pb.js", () => ({
@@ -242,6 +249,34 @@ describe("Edge Cases", () => {
       expect(domainToContextType("accommodation")).toBe("hotels");
       expect(domainToContextType("dining")).toBe("restaurants");
       expect(domainToContextType("itinerary")).toBe("itineraries");
+    });
+  });
+});
+
+describe("mapPoi", () => {
+  it("preserves server recommendation attribution", () => {
+    const proto = create(POIDetailedInfoSchema, {
+      id: "f6d8ed0a-eade-4a77-a82d-a72d8fa5833e",
+      name: "Miradouro",
+      recommendationTrace: create(RecommendationTraceSchema, {
+        runId: "run-123",
+        itemId: "f6d8ed0a-eade-4a77-a82d-a72d8fa5833e",
+        rank: 2,
+        algorithmVersion: "discover-gemini-v1",
+        experimentVariant: "personalized",
+        surface: RecommendationSurface.DISCOVER,
+        channel: RecommendationChannel.WEB,
+      }),
+    });
+
+    expect(mapPoi(proto).recommendation_trace).toEqual({
+      runId: "run-123",
+      itemId: "f6d8ed0a-eade-4a77-a82d-a72d8fa5833e",
+      rank: 2,
+      algorithmVersion: "discover-gemini-v1",
+      experimentVariant: "personalized",
+      surface: "RECOMMENDATION_SURFACE_DISCOVER",
+      channel: "RECOMMENDATION_CHANNEL_WEB",
     });
   });
 });

--- a/src/lib/api/llm.ts
+++ b/src/lib/api/llm.ts
@@ -22,6 +22,7 @@ import {
   RestaurantDetailedInfo as ProtoRestaurantDetailedInfo,
 } from "@buf/loci_loci-proto.bufbuild_es/loci/poi/poi_pb.js";
 import { transport } from "../connect-transport";
+import { fromProtoRecommendationTrace } from "./recommendations";
 import type { Timestamp } from "@bufbuild/protobuf/wkt";
 //import { createGraphQLClient, gql } from '@solid-primitives/graphql';
 import type {
@@ -159,6 +160,7 @@ export const mapPoi = (poi: ProtoPOIDetailedInfo): POIDetailedInfo => {
     description_poi: poi.descriptionPoi || "",
     recommendation_rationale: poi.recommendationRationale || "",
     uncertainty_score: poi.uncertaintyScore,
+    recommendation_trace: fromProtoRecommendationTrace(poi.recommendationTrace),
     created_at:
       poi.createdAt && typeof (poi.createdAt as any).toDate === "function"
         ? (poi.createdAt as any).toDate().toISOString()
@@ -206,6 +208,7 @@ const mapRestaurant = (
     (restaurant as ProtoRestaurantDetailedInfo).llmInteractionId ||
     (restaurant as ProtoPOIDetailedInfo).llmInteractionId ||
     "",
+  recommendation_trace: fromProtoRecommendationTrace(restaurant.recommendationTrace),
 });
 
 export const mapItineraryResponse = (

--- a/src/lib/api/place-intelligence.ts
+++ b/src/lib/api/place-intelligence.ts
@@ -1,0 +1,108 @@
+import { create } from "@bufbuild/protobuf";
+import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
+import {
+  GetMyContributorProfileRequestSchema,
+  ListVerificationTasksRequestSchema,
+  PlaceFactField as ProtoPlaceFactField,
+  PlaceIntelligenceService,
+  SubmitPlaceClaimRequestSchema,
+} from "@buf/loci_loci-proto.bufbuild_es/loci/place/place_intelligence_pb.js";
+import { createClient } from "@connectrpc/connect";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/solid-query";
+import { transport } from "~/lib/connect-transport";
+
+const placeClient = createClient(PlaceIntelligenceService, transport);
+
+export type PlaceFactField =
+  | "PLACE_FACT_FIELD_OPENING_HOURS"
+  | "PLACE_FACT_FIELD_PRICE_LEVEL"
+  | "PLACE_FACT_FIELD_ACCESSIBILITY"
+  | "PLACE_FACT_FIELD_DIETARY"
+  | "PLACE_FACT_FIELD_CROWD_LEVEL"
+  | "PLACE_FACT_FIELD_NOISE_LEVEL"
+  | "PLACE_FACT_FIELD_CHILD_FRIENDLY"
+  | "PLACE_FACT_FIELD_DOG_FRIENDLY"
+  | "PLACE_FACT_FIELD_VIBE";
+
+export interface VerificationTask {
+  poiId: string;
+  poiName: string;
+  requestedFields: PlaceFactField[];
+  oldestFactAt?: string;
+}
+
+export interface ContributorProfile {
+  reputation: number;
+  submittedClaims: number;
+  acceptedClaims: number;
+  badges: string[];
+}
+
+const fields: Record<PlaceFactField, ProtoPlaceFactField> = {
+  PLACE_FACT_FIELD_OPENING_HOURS: ProtoPlaceFactField.OPENING_HOURS,
+  PLACE_FACT_FIELD_PRICE_LEVEL: ProtoPlaceFactField.PRICE_LEVEL,
+  PLACE_FACT_FIELD_ACCESSIBILITY: ProtoPlaceFactField.ACCESSIBILITY,
+  PLACE_FACT_FIELD_DIETARY: ProtoPlaceFactField.DIETARY,
+  PLACE_FACT_FIELD_CROWD_LEVEL: ProtoPlaceFactField.CROWD_LEVEL,
+  PLACE_FACT_FIELD_NOISE_LEVEL: ProtoPlaceFactField.NOISE_LEVEL,
+  PLACE_FACT_FIELD_CHILD_FRIENDLY: ProtoPlaceFactField.CHILD_FRIENDLY,
+  PLACE_FACT_FIELD_DOG_FRIENDLY: ProtoPlaceFactField.DOG_FRIENDLY,
+  PLACE_FACT_FIELD_VIBE: ProtoPlaceFactField.VIBE,
+};
+
+const fieldNames = Object.fromEntries(
+  Object.entries(fields).map(([name, value]) => [value, name]),
+) as Record<ProtoPlaceFactField, PlaceFactField>;
+
+export const useVerificationTasks = () =>
+  useQuery(() => ({
+    queryKey: ["place-intelligence", "tasks"],
+    queryFn: async (): Promise<VerificationTask[]> => {
+      const response = await placeClient.listVerificationTasks(
+        create(ListVerificationTasksRequestSchema, { limit: 20 }),
+      );
+      return response.tasks.map((task) => ({
+        poiId: task.poiId,
+        poiName: task.poiName,
+        requestedFields: task.requestedFields
+          .map((field) => fieldNames[field])
+          .filter((field): field is PlaceFactField => Boolean(field)),
+        oldestFactAt: task.oldestFactAt
+          ? timestampDate(task.oldestFactAt).toISOString()
+          : undefined,
+      }));
+    },
+  }));
+
+export const useContributorProfile = () =>
+  useQuery(() => ({
+    queryKey: ["place-intelligence", "profile"],
+    queryFn: async (): Promise<ContributorProfile> => {
+      const profile = await placeClient.getMyContributorProfile(
+        create(GetMyContributorProfileRequestSchema, {}),
+      );
+      return {
+        reputation: profile.reputation,
+        submittedClaims: profile.submittedClaims,
+        acceptedClaims: profile.acceptedClaims,
+        badges: profile.badges,
+      };
+    },
+  }));
+
+export const useSubmitPlaceClaim = () => {
+  const queryClient = useQueryClient();
+  return useMutation(() => ({
+    mutationFn: (claim: { poiId: string; field: PlaceFactField; value: string }) =>
+      placeClient.submitPlaceClaim(
+        create(SubmitPlaceClaimRequestSchema, {
+          clientClaimId: crypto.randomUUID(),
+          observedAt: timestampFromDate(new Date()),
+          poiId: claim.poiId,
+          field: fields[claim.field],
+          value: claim.value,
+        }),
+      ),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["place-intelligence"] }),
+  }));
+};

--- a/src/lib/api/pois.ts
+++ b/src/lib/api/pois.ts
@@ -187,18 +187,20 @@ export const useNearbyPOIs = (params?: {
 export const useSearchPOIs = (query: string, filters?: any) => {
   return useQuery(() => ({
     queryKey: queryKeys.searchPois(query, filters),
-    queryFn: async (): Promise<POI[]> => {
-      const response = await poiClient.searchPOI({
-        query,
-        cityName: filters?.cityName || filters?.city || "",
-        latitude: filters?.latitude || 0,
-        longitude: filters?.longitude || 0,
-        radiusKm: filters?.radiusKm,
-        searchType: filters?.searchType || "semantic",
-      });
-      return response.pois.map(mapProtoPOI);
-    },
+    queryFn: async (): Promise<POI[]> => searchPOIs(query, filters),
     enabled: !!query,
     staleTime: 5 * 60 * 1000,
   }));
+};
+
+export const searchPOIs = async (query: string, filters?: any): Promise<POI[]> => {
+  const response = await poiClient.searchPOI({
+    query,
+    cityName: filters?.cityName || filters?.city || "",
+    latitude: filters?.latitude || 0,
+    longitude: filters?.longitude || 0,
+    radiusKm: filters?.radiusKm,
+    searchType: filters?.searchType || "semantic",
+  });
+  return response.pois.map(mapProtoPOI);
 };

--- a/src/lib/api/recommendations.ts
+++ b/src/lib/api/recommendations.ts
@@ -1,0 +1,253 @@
+import { create } from "@bufbuild/protobuf";
+import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
+import {
+  GetPersonalizationSettingsRequestSchema,
+  GetTasteProfileRequestSchema,
+  PersonalizationSettings as ProtoPersonalizationSettings,
+  RecommendationChannel,
+  RecommendationEventSchema,
+  RecommendationEventType,
+  RecommendationService,
+  RecommendationSurface,
+  type RecommendationTrace as ProtoRecommendationTrace,
+  RecommendationTraceSchema,
+  RecordEventsRequestSchema,
+  ResetTasteProfileRequestSchema,
+  TasteProfile as ProtoTasteProfile,
+  UpdatePersonalizationSettingsRequestSchema,
+} from "@buf/loci_loci-proto.bufbuild_es/loci/recommendation/recommendation_pb.js";
+import { createClient } from "@connectrpc/connect";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/solid-query";
+import { getAuthToken } from "../auth/tokens";
+import { transport } from "../connect-transport";
+
+const recommendationClient = createClient(RecommendationService, transport);
+
+export type RecommendationSurfaceName =
+  | "RECOMMENDATION_SURFACE_DISCOVER"
+  | "RECOMMENDATION_SURFACE_NEARBY"
+  | "RECOMMENDATION_SURFACE_CHAT"
+  | "RECOMMENDATION_SURFACE_TRIP"
+  | "RECOMMENDATION_SURFACE_PLACE";
+
+export type RecommendationChannelName = "RECOMMENDATION_CHANNEL_WEB" | "RECOMMENDATION_CHANNEL_MCP";
+
+export type RecommendationEventName =
+  | "RECOMMENDATION_EVENT_TYPE_DELIVERED"
+  | "RECOMMENDATION_EVENT_TYPE_PRESENTED"
+  | "RECOMMENDATION_EVENT_TYPE_OPENED"
+  | "RECOMMENDATION_EVENT_TYPE_DISMISSED"
+  | "RECOMMENDATION_EVENT_TYPE_FAVORITED"
+  | "RECOMMENDATION_EVENT_TYPE_ADDED_TO_LIST"
+  | "RECOMMENDATION_EVENT_TYPE_ADDED_TO_TRIP"
+  | "RECOMMENDATION_EVENT_TYPE_KEPT_IN_TRIP"
+  | "RECOMMENDATION_EVENT_TYPE_REMOVED_FROM_TRIP"
+  | "RECOMMENDATION_EVENT_TYPE_EXPORTED"
+  | "RECOMMENDATION_EVENT_TYPE_BOOKING_OPENED"
+  | "RECOMMENDATION_EVENT_TYPE_VISIT_CONFIRMED"
+  | "RECOMMENDATION_EVENT_TYPE_RATED";
+
+export interface RecommendationTrace {
+  runId: string;
+  itemId: string;
+  rank: number;
+  algorithmVersion: string;
+  experimentVariant: string;
+  surface: RecommendationSurfaceName;
+  channel: RecommendationChannelName;
+}
+
+export interface RecommendationEvent {
+  eventType: RecommendationEventName;
+  trace: RecommendationTrace;
+  poiId?: string;
+  tripId?: string;
+  rating?: number;
+  metadata?: Record<string, string>;
+}
+
+export interface PersonalizationSettings {
+  personalizationEnabled: boolean;
+  contributeAggregate: boolean;
+  disclosureSeen: boolean;
+  updatedAt: string;
+}
+
+export interface TasteProfile {
+  traits: Array<{
+    key: string;
+    label: string;
+    score: number;
+    confidence: number;
+    evidenceCount: number;
+  }>;
+  feedbackCount: number;
+  algorithmVersion: string;
+  lastFeedbackAt?: string;
+  updatedAt: string;
+}
+
+const surfaces: Record<RecommendationSurfaceName, RecommendationSurface> = {
+  RECOMMENDATION_SURFACE_DISCOVER: RecommendationSurface.DISCOVER,
+  RECOMMENDATION_SURFACE_NEARBY: RecommendationSurface.NEARBY,
+  RECOMMENDATION_SURFACE_CHAT: RecommendationSurface.CHAT,
+  RECOMMENDATION_SURFACE_TRIP: RecommendationSurface.TRIP,
+  RECOMMENDATION_SURFACE_PLACE: RecommendationSurface.PLACE,
+};
+
+const channels: Record<RecommendationChannelName, RecommendationChannel> = {
+  RECOMMENDATION_CHANNEL_WEB: RecommendationChannel.WEB,
+  RECOMMENDATION_CHANNEL_MCP: RecommendationChannel.MCP,
+};
+
+const eventTypes: Record<RecommendationEventName, RecommendationEventType> = {
+  RECOMMENDATION_EVENT_TYPE_DELIVERED: RecommendationEventType.DELIVERED,
+  RECOMMENDATION_EVENT_TYPE_PRESENTED: RecommendationEventType.PRESENTED,
+  RECOMMENDATION_EVENT_TYPE_OPENED: RecommendationEventType.OPENED,
+  RECOMMENDATION_EVENT_TYPE_DISMISSED: RecommendationEventType.DISMISSED,
+  RECOMMENDATION_EVENT_TYPE_FAVORITED: RecommendationEventType.FAVORITED,
+  RECOMMENDATION_EVENT_TYPE_ADDED_TO_LIST: RecommendationEventType.ADDED_TO_LIST,
+  RECOMMENDATION_EVENT_TYPE_ADDED_TO_TRIP: RecommendationEventType.ADDED_TO_TRIP,
+  RECOMMENDATION_EVENT_TYPE_KEPT_IN_TRIP: RecommendationEventType.KEPT_IN_TRIP,
+  RECOMMENDATION_EVENT_TYPE_REMOVED_FROM_TRIP: RecommendationEventType.REMOVED_FROM_TRIP,
+  RECOMMENDATION_EVENT_TYPE_EXPORTED: RecommendationEventType.EXPORTED,
+  RECOMMENDATION_EVENT_TYPE_BOOKING_OPENED: RecommendationEventType.BOOKING_OPENED,
+  RECOMMENDATION_EVENT_TYPE_VISIT_CONFIRMED: RecommendationEventType.VISIT_CONFIRMED,
+  RECOMMENDATION_EVENT_TYPE_RATED: RecommendationEventType.RATED,
+};
+
+const surfaceNames: Partial<Record<RecommendationSurface, RecommendationSurfaceName>> = {
+  [RecommendationSurface.DISCOVER]: "RECOMMENDATION_SURFACE_DISCOVER",
+  [RecommendationSurface.NEARBY]: "RECOMMENDATION_SURFACE_NEARBY",
+  [RecommendationSurface.CHAT]: "RECOMMENDATION_SURFACE_CHAT",
+  [RecommendationSurface.TRIP]: "RECOMMENDATION_SURFACE_TRIP",
+  [RecommendationSurface.PLACE]: "RECOMMENDATION_SURFACE_PLACE",
+};
+
+const channelNames: Partial<Record<RecommendationChannel, RecommendationChannelName>> = {
+  [RecommendationChannel.WEB]: "RECOMMENDATION_CHANNEL_WEB",
+  [RecommendationChannel.MCP]: "RECOMMENDATION_CHANNEL_MCP",
+};
+
+export function fromProtoRecommendationTrace(
+  trace?: ProtoRecommendationTrace,
+): RecommendationTrace | undefined {
+  if (!trace?.runId || !trace.itemId) return undefined;
+  const surface = surfaceNames[trace.surface];
+  const channel = channelNames[trace.channel];
+  if (!surface || !channel) return undefined;
+  return {
+    runId: trace.runId,
+    itemId: trace.itemId,
+    rank: trace.rank,
+    algorithmVersion: trace.algorithmVersion,
+    experimentVariant: trace.experimentVariant,
+    surface,
+    channel,
+  };
+}
+
+export function normalizeRecommendationTrace(
+  trace?: ProtoRecommendationTrace | RecommendationTrace,
+): RecommendationTrace | undefined {
+  if (!trace) return undefined;
+  if (typeof trace.surface === "string") return trace as RecommendationTrace;
+  return fromProtoRecommendationTrace(trace as ProtoRecommendationTrace);
+}
+
+export const toProtoRecommendationTrace = (trace?: RecommendationTrace) =>
+  trace
+    ? create(RecommendationTraceSchema, {
+        ...trace,
+        surface: surfaces[trace.surface],
+        channel: channels[trace.channel],
+      })
+    : undefined;
+
+const mapSettings = (settings: ProtoPersonalizationSettings): PersonalizationSettings => ({
+  personalizationEnabled: settings.personalizationEnabled,
+  contributeAggregate: settings.contributeAggregate,
+  disclosureSeen: settings.disclosureSeen,
+  updatedAt: settings.updatedAt ? timestampDate(settings.updatedAt).toISOString() : "",
+});
+
+const mapTasteProfile = (profile: ProtoTasteProfile): TasteProfile => ({
+  traits: profile.traits.map((trait) => ({
+    key: trait.key,
+    label: trait.label,
+    score: trait.score,
+    confidence: trait.confidence,
+    evidenceCount: trait.evidenceCount,
+  })),
+  feedbackCount: profile.feedbackCount,
+  algorithmVersion: profile.algorithmVersion,
+  lastFeedbackAt: profile.lastFeedbackAt
+    ? timestampDate(profile.lastFeedbackAt).toISOString()
+    : undefined,
+  updatedAt: profile.updatedAt ? timestampDate(profile.updatedAt).toISOString() : "",
+});
+
+export async function recordRecommendationEvents(events: RecommendationEvent[]) {
+  if (events.length === 0 || !getAuthToken()) return { accepted: 0, duplicates: 0 };
+
+  return recommendationClient.recordEvents(
+    create(RecordEventsRequestSchema, {
+      events: events.map((event) =>
+        create(RecommendationEventSchema, {
+          clientEventId: crypto.randomUUID(),
+          eventType: eventTypes[event.eventType],
+          occurredAt: timestampFromDate(new Date()),
+          trace: toProtoRecommendationTrace(event.trace),
+          poiId: event.poiId,
+          tripId: event.tripId,
+          rating: event.rating,
+          metadata: event.metadata ?? {},
+        }),
+      ),
+    }),
+  );
+}
+
+export const usePersonalizationSettings = () =>
+  useQuery(() => ({
+    queryKey: ["recommendation", "settings"],
+    queryFn: async () =>
+      mapSettings(
+        await recommendationClient.getPersonalizationSettings(
+          create(GetPersonalizationSettingsRequestSchema, {}),
+        ),
+      ),
+  }));
+
+export const useTasteProfile = () =>
+  useQuery(() => ({
+    queryKey: ["recommendation", "taste-profile"],
+    queryFn: async () =>
+      mapTasteProfile(
+        await recommendationClient.getTasteProfile(create(GetTasteProfileRequestSchema, {})),
+      ),
+  }));
+
+export const useUpdatePersonalizationSettings = () => {
+  const queryClient = useQueryClient();
+  return useMutation(() => ({
+    mutationFn: async (settings: Omit<PersonalizationSettings, "updatedAt">) =>
+      mapSettings(
+        await recommendationClient.updatePersonalizationSettings(
+          create(UpdatePersonalizationSettingsRequestSchema, settings),
+        ),
+      ),
+    onSuccess: (settings) => queryClient.setQueryData(["recommendation", "settings"], settings),
+  }));
+};
+
+export const useResetTasteProfile = () => {
+  const queryClient = useQueryClient();
+  return useMutation(() => ({
+    mutationFn: () =>
+      recommendationClient.resetTasteProfile(
+        create(ResetTasteProfileRequestSchema, { confirmation: "RESET" }),
+      ),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["recommendation"] }),
+  }));
+};

--- a/src/lib/api/trips.ts
+++ b/src/lib/api/trips.ts
@@ -12,18 +12,28 @@ import {
   ListTripsRequestSchema,
   ShareTripRequestSchema,
   ReorderStopsRequestSchema,
+  AddStopRequestSchema,
+  RemoveStopRequestSchema,
+  ReplaceStopRequestSchema,
   RenameStopRequestSchema,
   EditStopDurationRequestSchema,
   SetConstraintRequestSchema,
   ExportTripRequestSchema,
   ExportFormat,
   TripPace,
+  TripStopSchema,
   type TripDraft as ProtoTripDraft,
   type TripConstraint as ProtoTripConstraint,
 } from "@buf/loci_loci-proto.bufbuild_es/loci/trip/trip_pb.js";
 import { PaginationRequestSchema } from "@buf/loci_loci-proto.bufbuild_es/loci/common/common_pb.js";
 import { transport } from "../connect-transport";
 import { cacheTripOffline, getCachedTrip } from "../trip-offline-cache";
+import {
+  fromProtoRecommendationTrace,
+  recordRecommendationEvents,
+  toProtoRecommendationTrace,
+  type RecommendationTrace,
+} from "./recommendations";
 
 const tripClient = createClient(TripService, transport);
 
@@ -40,6 +50,7 @@ export interface TripStop {
   durationMinutes?: number;
   notes: string;
   bookingUrl?: string;
+  recommendationTrace?: RecommendationTrace;
 }
 
 export interface TripDay {
@@ -107,6 +118,7 @@ const mapTrip = (p: ProtoTripDraft): Trip => ({
       durationMinutes: s.durationMinutes,
       notes: s.notes,
       bookingUrl: s.bookingUrl,
+      recommendationTrace: fromProtoRecommendationTrace(s.recommendationTrace),
     })),
   })),
 });
@@ -114,6 +126,19 @@ const mapTrip = (p: ProtoTripDraft): Trip => ({
 // Build the proto TripDraft for a save. Server-owned fields (ids, timestamps,
 // user_id) are filled with placeholders to satisfy validation; the server
 // assigns the real values (new day/stop ids are generated on insert).
+const toProtoStop = (s: TripStop) =>
+  create(TripStopSchema, {
+    id: s.id || crypto.randomUUID(),
+    poiId: s.poiId,
+    orderIndex: s.orderIndex,
+    name: s.name || "Stop",
+    startMinute: s.startMinute,
+    durationMinutes: s.durationMinutes,
+    notes: s.notes,
+    bookingUrl: s.bookingUrl,
+    recommendationTrace: toProtoRecommendationTrace(s.recommendationTrace),
+  });
+
 const toProtoTrip = (t: Trip) =>
   create(TripDraftSchema, {
     id: t.id || "",
@@ -137,16 +162,7 @@ const toProtoTrip = (t: Trip) =>
       id: d.id || crypto.randomUUID(),
       dayNumber: d.dayNumber,
       date: d.date ? timestampFromDate(new Date(d.date)) : undefined,
-      stops: d.stops.map((s) => ({
-        id: s.id || crypto.randomUUID(),
-        poiId: s.poiId,
-        orderIndex: s.orderIndex,
-        name: s.name || "Stop",
-        startMinute: s.startMinute,
-        durationMinutes: s.durationMinutes,
-        notes: s.notes,
-        bookingUrl: s.bookingUrl,
-      })),
+      stops: d.stops.map(toProtoStop),
     })),
   });
 
@@ -209,11 +225,17 @@ export const useSaveTrip = () => {
 };
 
 // Each fine-grained mutation returns the updated trip (bumped version).
-const detailMutation = <TInput>(fn: (input: TInput) => Promise<ProtoTripDraft>) => {
+const detailMutation = <TInput>(
+  fn: (input: TInput) => Promise<ProtoTripDraft>,
+  afterSuccess?: (trip: Trip, input: TInput) => void,
+) => {
   const qc = useQueryClient();
   return useMutation(() => ({
     mutationFn: async (input: TInput) => mapTrip(await fn(input)),
-    onSuccess: (t: Trip) => qc.setQueryData(tripKeys.detail(t.id), t),
+    onSuccess: (t: Trip, input: TInput) => {
+      qc.setQueryData(tripKeys.detail(t.id), t);
+      afterSuccess?.(t, input);
+    },
   }));
 };
 
@@ -250,6 +272,88 @@ export const useSetConstraint = () =>
     ),
   );
 
+export const useAddStop = () =>
+  detailMutation(
+    (i: { tripId: string; dayId: string; stop: TripStop; baseVersion: bigint }) =>
+      tripClient.addStop(
+        create(AddStopRequestSchema, {
+          tripId: i.tripId,
+          dayId: i.dayId,
+          stop: toProtoStop(i.stop),
+          baseVersion: i.baseVersion,
+        }),
+      ),
+    (trip, input) => {
+      if (!input.stop.recommendationTrace) return;
+      void recordRecommendationEvents([
+        {
+          eventType: "RECOMMENDATION_EVENT_TYPE_ADDED_TO_TRIP",
+          trace: input.stop.recommendationTrace,
+          poiId: input.stop.poiId,
+          tripId: trip.id,
+        },
+      ]);
+    },
+  );
+
+export const useRemoveStop = () =>
+  detailMutation(
+    (i: { tripId: string; stop: TripStop; baseVersion: bigint }) =>
+      tripClient.removeStop(
+        create(RemoveStopRequestSchema, {
+          tripId: i.tripId,
+          stopId: i.stop.id,
+          baseVersion: i.baseVersion,
+        }),
+      ),
+    (trip, input) => {
+      if (!input.stop.recommendationTrace) return;
+      void recordRecommendationEvents([
+        {
+          eventType: "RECOMMENDATION_EVENT_TYPE_REMOVED_FROM_TRIP",
+          trace: input.stop.recommendationTrace,
+          poiId: input.stop.poiId,
+          tripId: trip.id,
+        },
+      ]);
+    },
+  );
+
+export const useReplaceStop = () =>
+  detailMutation(
+    (i: { tripId: string; currentStop: TripStop; replacement: TripStop; baseVersion: bigint }) =>
+      tripClient.replaceStop(
+        create(ReplaceStopRequestSchema, {
+          tripId: i.tripId,
+          stopId: i.currentStop.id,
+          replacement: toProtoStop(i.replacement),
+          baseVersion: i.baseVersion,
+        }),
+      ),
+    (trip, input) => {
+      const events = [];
+      if (input.currentStop.recommendationTrace) {
+        events.push({
+          eventType: "RECOMMENDATION_EVENT_TYPE_REMOVED_FROM_TRIP" as const,
+          trace: input.currentStop.recommendationTrace,
+          poiId: input.currentStop.poiId,
+          tripId: trip.id,
+          metadata: { action: "replaced" },
+        });
+      }
+      if (input.replacement.recommendationTrace) {
+        events.push({
+          eventType: "RECOMMENDATION_EVENT_TYPE_ADDED_TO_TRIP" as const,
+          trace: input.replacement.recommendationTrace,
+          poiId: input.replacement.poiId,
+          tripId: trip.id,
+          metadata: { action: "replacement" },
+        });
+      }
+      void recordRecommendationEvents(events);
+    },
+  );
+
 export const useShareTrip = () =>
   useMutation(() => ({
     mutationFn: async (i: { tripId: string; isPublic: boolean }) =>
@@ -257,16 +361,18 @@ export const useShareTrip = () =>
   }));
 
 // Export a trip to ICS and trigger a browser download.
-export const exportTripICS = async (tripId: string) => exportTrip(tripId, ExportFormat.ICS);
+export const exportTripICS = async (tripId: string, trip?: Trip) =>
+  exportTrip(tripId, ExportFormat.ICS, trip);
 
 /** Export trip as PDF (Pro-gated on server for multi-day; client soft-gates UX). */
-export const exportTripPDF = async (tripId: string) => exportTrip(tripId, ExportFormat.PDF);
+export const exportTripPDF = async (tripId: string, trip?: Trip) =>
+  exportTrip(tripId, ExportFormat.PDF, trip);
 
 /** Export trip as Markdown (Pro-only on server). */
-export const exportTripMarkdown = async (tripId: string) =>
-  exportTrip(tripId, ExportFormat.MARKDOWN);
+export const exportTripMarkdown = async (tripId: string, trip?: Trip) =>
+  exportTrip(tripId, ExportFormat.MARKDOWN, trip);
 
-async function exportTrip(tripId: string, format: ExportFormat) {
+async function exportTrip(tripId: string, format: ExportFormat, trip?: Trip) {
   const res = await tripClient.exportTrip(create(ExportTripRequestSchema, { tripId, format }));
   const blob = new Blob([res.data as unknown as BlobPart], {
     type:
@@ -291,4 +397,19 @@ async function exportTrip(tripId: string, format: ExportFormat) {
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
+  if (trip) {
+    void recordRecommendationEvents(
+      trip.days.flatMap((day) =>
+        day.stops
+          .filter((stop) => stop.recommendationTrace)
+          .map((stop) => ({
+            eventType: "RECOMMENDATION_EVENT_TYPE_EXPORTED" as const,
+            trace: stop.recommendationTrace!,
+            poiId: stop.poiId,
+            tripId,
+            metadata: { format: ExportFormat[format]?.toLowerCase() || String(format) },
+          })),
+      ),
+    );
+  }
 }

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -1,4 +1,5 @@
 // Type definitions for API responses
+import type { RecommendationTrace } from "./recommendations";
 
 export interface UserProfile {
   id: string;
@@ -111,6 +112,8 @@ export interface POI {
   city_id?: string;
   llm_interaction_id?: string;
   created_at?: string;
+  recommendation_trace?: RecommendationTrace;
+  recommendation_rationale?: string;
 }
 
 export interface ChatMessage {
@@ -511,6 +514,7 @@ export interface HotelDetailedInfo {
   images: string[];
   rating: number;
   llm_interaction_id: string;
+  recommendation_trace?: RecommendationTrace;
   // Extended fields for detail page
   checkIn?: string;
   checkOut?: string;
@@ -561,6 +565,7 @@ export interface RestaurantDetailedInfo {
   images: string[];
   rating: number;
   llm_interaction_id: string;
+  recommendation_trace?: RecommendationTrace;
   // Extended fields for detail page
   reviewCount?: number;
   isOpen?: boolean;
@@ -616,6 +621,7 @@ export interface POIDetailedInfo {
   star_rating?: number;
   recommendation_rationale?: string;
   uncertainty_score?: number;
+  recommendation_trace?: RecommendationTrace;
 }
 
 // Domain-specific response types

--- a/src/lib/theme-colors.ts
+++ b/src/lib/theme-colors.ts
@@ -2,7 +2,7 @@ import type { DesignTheme } from "~/lib/theme-preference";
 
 /** Browser chrome / PWA theme-color per design + resolved color mode. */
 export const THEME_COLOR_PALETTE: Record<DesignTheme, { light: string; dark: string }> = {
-  loci: { light: "#1a1a1a", dark: "#0a0a0a" },
+  loci: { light: "#294d3c", dark: "#14251e" },
   classic: { light: "#8a6e2f", dark: "#5c4033" },
   modern: { light: "#0c7df2", dark: "#1e3a8a" },
 };
@@ -11,6 +11,21 @@ export const MAPBOX_STYLES = {
   light: "mapbox://styles/mapbox/light-v11",
   dark: "mapbox://styles/mapbox/dark-v11",
 } as const;
+
+/** Itinerary day marker + route colors — forest → sage → terracotta scale. */
+export const LOCI_DAY_COLORS = [
+  "#294d3c", // forest ink (day 0)
+  "#5a7a55", // sage
+  "#c76b4a", // terracotta
+  "#8a6e2f", // field amber
+  "#3d5a4a", // deep sage
+  "#a85a3a", // burnt terracotta
+  "#6b8f71", // light sage
+  "#d4845c", // warm clay
+] as const;
+
+export const LOCI_MAP_CLUSTER_COLOR = "#294d3c";
+export const LOCI_MAP_UNGROUPED_COLOR = "#6b7c72";
 
 export const themeColorFor = (design: DesignTheme, isDark: boolean): string =>
   THEME_COLOR_PALETTE[design][isDark ? "dark" : "light"];
@@ -25,3 +40,8 @@ export const readThemeColorFromDocument = (): string => {
 
 export const mapStyleForColorMode = (isDark: boolean): string =>
   isDark ? MAPBOX_STYLES.dark : MAPBOX_STYLES.light;
+
+export const colorForMapDay = (day?: number): string =>
+  typeof day === "number"
+    ? LOCI_DAY_COLORS[day % LOCI_DAY_COLORS.length]
+    : LOCI_MAP_UNGROUPED_COLOR;

--- a/src/routes/activities/index.tsx
+++ b/src/routes/activities/index.tsx
@@ -217,7 +217,7 @@ export default function ActivitiesPage() {
 
   return (
     <>
-      <SplitView listContent={ListContent} mapContent={MapContent} initialMode="split" />
+      <SplitView listContent={ListContent} mapContent={MapContent} initialMode="map" />
       <FloatingChat
         getStreamingData={() => effectiveData()}
         setStreamingData={(fn) => {

--- a/src/routes/chat/index.tsx
+++ b/src/routes/chat/index.tsx
@@ -14,44 +14,38 @@ const DetailedItemModal = lazy(() => import("~/components/DetailedItemModal"));
 const QUICK_PROMPTS: QuickPrompt[] = [
   {
     id: "1",
-    icon: "🌟",
     text: "Hidden gems in Paris",
     description: "Discover off-the-beaten-path spots",
     domain: "general",
   },
   {
     id: "2",
-    icon: "🍕",
     text: "Best food markets in Italy",
     description: "Authentic local markets and food",
     domain: "dining",
   },
   {
     id: "3",
-    icon: "🏛️",
     text: "3-day cultural tour of Rome",
     description: "Museums, history, and architecture",
     domain: "itinerary",
   },
   {
     id: "4",
-    icon: "👨‍👩‍👧‍👦",
     text: "Family weekend in Amsterdam",
     description: "Kid-friendly activities and places",
     domain: "activities",
   },
   {
     id: "5",
-    icon: "📸",
-    text: "Instagram spots in Santorini",
-    description: "Most photogenic locations",
+    text: "Photogenic spots in Santorini",
+    description: "Calm viewpoints and walking routes",
     domain: "general",
   },
   {
     id: "6",
-    icon: "🎭",
     text: "Nightlife in Berlin",
-    description: "Bars, clubs, and entertainment",
+    description: "Bars, clubs, and evening culture",
     domain: "activities",
   },
 ];

--- a/src/routes/contribute.tsx
+++ b/src/routes/contribute.tsx
@@ -1,0 +1,182 @@
+import { createMemo, createSignal, For, Show } from "solid-js";
+import { CheckCircle2, MapPin, ShieldCheck, Users } from "lucide-solid";
+import {
+  type PlaceFactField,
+  type VerificationTask,
+  useContributorProfile,
+  useSubmitPlaceClaim,
+  useVerificationTasks,
+} from "~/lib/api/place-intelligence";
+import { Button } from "~/ui/button";
+
+const fieldLabel = (field: PlaceFactField) =>
+  field
+    .replace("PLACE_FACT_FIELD_", "")
+    .toLowerCase()
+    .split("_")
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(" ");
+
+export default function ContributePage() {
+  const tasks = useVerificationTasks();
+  const profile = useContributorProfile();
+  const submit = useSubmitPlaceClaim();
+  const [selected, setSelected] = createSignal<VerificationTask>();
+  const [field, setField] = createSignal<PlaceFactField>();
+  const [value, setValue] = createSignal("");
+  const selectedFields = createMemo(() => selected()?.requestedFields || []);
+
+  const selectTask = (task: VerificationTask) => {
+    setSelected(task);
+    setField(task.requestedFields[0]);
+    setValue("");
+  };
+
+  return (
+    <main class="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
+      <section class="loci-hero">
+        <div class="loci-hero__content grid gap-8 p-7 sm:p-10 md:grid-cols-[1fr_auto] md:items-end">
+          <div>
+            <p class="font-coord text-[10px] uppercase tracking-[0.2em] text-primary-foreground/65">
+              Local scout network
+            </p>
+            <h1 class="mt-3 max-w-2xl text-4xl text-primary-foreground sm:text-5xl">
+              Make the field guide more true.
+            </h1>
+            <p class="mt-4 max-w-xl text-sm leading-6 text-primary-foreground/72">
+              Confirm the useful details algorithms miss: current hours, accessibility, noise,
+              crowds, and the feel of a place.
+            </p>
+          </div>
+          <div class="grid grid-cols-3 gap-3 text-center">
+            <div class="loci-hero__stat">
+              <b class="block text-xl">{profile.data?.reputation || 0}</b>
+              <span class="text-[10px] text-primary-foreground/60">Reputation</span>
+            </div>
+            <div class="loci-hero__stat">
+              <b class="block text-xl">{profile.data?.submittedClaims || 0}</b>
+              <span class="text-[10px] text-primary-foreground/60">Reports</span>
+            </div>
+            <div class="loci-hero__stat">
+              <b class="block text-xl">{profile.data?.acceptedClaims || 0}</b>
+              <span class="text-[10px] text-primary-foreground/60">Verified</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="mt-8 grid gap-6 lg:grid-cols-[1fr_0.8fr]">
+        <section>
+          <div class="mb-4 flex items-end justify-between gap-4">
+            <div>
+              <p class="font-coord text-[10px] uppercase tracking-[0.18em] text-accent">
+                Nearby knowledge gaps
+              </p>
+              <h2 class="mt-1 text-2xl">Places that need a fresh look</h2>
+            </div>
+            <span class="text-xs text-muted-foreground">Two matching reports verify a fact</span>
+          </div>
+          <div class="grid gap-3">
+            <For
+              each={tasks.data}
+              fallback={<div class="h-32 animate-pulse rounded-xl bg-muted" />}
+            >
+              {(task) => (
+                <button
+                  type="button"
+                  onClick={() => selectTask(task)}
+                  class={`w-full rounded-xl border bg-card p-5 text-left transition hover:border-accent ${selected()?.poiId === task.poiId ? "border-accent ring-2 ring-accent/15" : "border-border"}`}
+                >
+                  <div class="flex items-start justify-between gap-4">
+                    <div class="flex gap-3">
+                      <MapPin class="mt-0.5 h-5 w-5 text-accent" />
+                      <div>
+                        <h3 class="text-lg">{task.poiName}</h3>
+                        <p class="mt-1 text-xs text-muted-foreground">
+                          Needs {task.requestedFields.map(fieldLabel).join(", ")}
+                        </p>
+                      </div>
+                    </div>
+                    <span class="font-coord text-[9px] uppercase tracking-wider text-muted-foreground">
+                      Verify
+                    </span>
+                  </div>
+                </button>
+              )}
+            </For>
+          </div>
+        </section>
+
+        <aside class="h-fit rounded-xl border border-border bg-card p-6 lg:sticky lg:top-24">
+          <Show
+            when={selected()}
+            fallback={
+              <div class="py-10 text-center">
+                <Users class="mx-auto h-7 w-7 text-muted-foreground" />
+                <h2 class="mt-4 text-xl">Choose a place</h2>
+                <p class="mt-2 text-sm text-muted-foreground">
+                  Share only what you observed yourself and recently.
+                </p>
+              </div>
+            }
+          >
+            {(task) => (
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  const selectedField = field();
+                  if (!selectedField || !value().trim()) return;
+                  submit.mutate(
+                    { poiId: task().poiId, field: selectedField, value: value().trim() },
+                    { onSuccess: () => setValue("") },
+                  );
+                }}
+              >
+                <p class="font-coord text-[10px] uppercase tracking-[0.18em] text-accent">
+                  Field report
+                </p>
+                <h2 class="mt-2 text-2xl">{task().poiName}</h2>
+                <label class="mt-6 block text-sm font-semibold">What did you verify?</label>
+                <select
+                  value={field()}
+                  onChange={(event) => setField(event.currentTarget.value as PlaceFactField)}
+                  class="mt-2 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                >
+                  <For each={selectedFields()}>
+                    {(item) => <option value={item}>{fieldLabel(item)}</option>}
+                  </For>
+                </select>
+                <label class="mt-5 block text-sm font-semibold">What is true right now?</label>
+                <textarea
+                  value={value()}
+                  onInput={(event) => setValue(event.currentTarget.value)}
+                  rows={4}
+                  maxlength={1000}
+                  placeholder="Be specific and concise…"
+                  class="mt-2 w-full rounded-lg border border-border bg-background p-3 text-sm"
+                />
+                <div class="mt-4 flex items-start gap-2 rounded-lg bg-secondary/60 p-3 text-xs leading-5 text-secondary-foreground">
+                  <ShieldCheck class="mt-0.5 h-4 w-4 shrink-0" /> Reports expire as places change.
+                  Your reputation grows when another scout corroborates your observation.
+                </div>
+                <Button
+                  type="submit"
+                  class="mt-5 w-full gap-2"
+                  disabled={!value().trim() || submit.isPending}
+                >
+                  <CheckCircle2 class="h-4 w-4" />
+                  {submit.isPending ? "Submitting…" : "Submit field report"}
+                </Button>
+                <Show when={submit.isSuccess}>
+                  <p class="mt-3 text-center text-sm text-accent">
+                    Report received. Thank you, scout.
+                  </p>
+                </Show>
+              </form>
+            )}
+          </Show>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/src/routes/discover.tsx
+++ b/src/routes/discover.tsx
@@ -38,6 +38,7 @@ import { useSelection, type SelectionItem } from "~/lib/hooks/useSelection";
 import { SelectionToolbar } from "~/components/ui/SelectionToolbar";
 import { exportPOIsToPDF } from "~/lib/utils/pdf-export";
 import EditTripCTA from "~/components/trip/EditTripCTA";
+import AddToTripButton from "~/components/trip/AddToTripButton";
 import AdvancedFiltersBar, {
   advancedFilterPromptSuffix,
   type AdvancedFilterId,
@@ -681,6 +682,7 @@ export default function DiscoverPage() {
                                   Open place
                                 </a>
                               </Show>
+                              <AddToTripButton poi={poi} />
                             </div>
                           </div>
                         );

--- a/src/routes/discover.tsx
+++ b/src/routes/discover.tsx
@@ -12,7 +12,21 @@ import {
   Clock,
   MapPin,
   Smartphone,
+  Utensils,
+  Bed,
+  Target,
+  Landmark,
+  Moon,
+  ShoppingBag,
+  Palette,
+  Trees,
+  Waves,
+  Mountain,
+  Drama,
+  Store,
 } from "lucide-solid";
+import WhyThisStop from "~/components/poi/WhyThisStop";
+import { deriveWhyThis } from "~/lib/why-this";
 import { useDiscoverPageData, fetchRecentDiscoveries } from "~/lib/api/discover";
 import type { TrendingDiscovery, POI, DomainType, ChatSession } from "~/lib/api/types";
 import { useAuth } from "~/contexts/AuthContext";
@@ -30,6 +44,10 @@ import AdvancedFiltersBar, {
 } from "~/components/filters/AdvancedFiltersBar";
 import { useUserSubscription } from "~/lib/api/billing";
 import { isProPlan } from "~/lib/subscription";
+import {
+  normalizeRecommendationTrace,
+  recordRecommendationEvents,
+} from "~/lib/api/recommendations";
 
 export default function DiscoverPage() {
   const { isAuthenticated } = useAuth();
@@ -65,19 +83,21 @@ export default function DiscoverPage() {
 
   // Category data matching go-templui
   const categories = [
-    { name: "Restaurants", emoji: "🍽️", category: "restaurant" },
-    { name: "Hotels", emoji: "🏨", category: "hotel" },
-    { name: "Activities", emoji: "🎯", category: "activity" },
-    { name: "Attractions", emoji: "🏛️", category: "attraction" },
-    { name: "Nightlife", emoji: "🌃", category: "nightlife" },
-    { name: "Shopping", emoji: "🛍️", category: "shopping" },
-    { name: "Museums", emoji: "🎨", category: "museum" },
-    { name: "Parks", emoji: "🌳", category: "park" },
-    { name: "Beaches", emoji: "🏖️", category: "beach" },
-    { name: "Adventure", emoji: "⛰️", category: "adventure" },
-    { name: "Cultural", emoji: "🎭", category: "cultural" },
-    { name: "Markets", emoji: "🏪", category: "market" },
+    { name: "Restaurants", icon: Utensils, category: "restaurant" },
+    { name: "Hotels", icon: Bed, category: "hotel" },
+    { name: "Activities", icon: Target, category: "activity" },
+    { name: "Attractions", icon: Landmark, category: "attraction" },
+    { name: "Nightlife", icon: Moon, category: "nightlife" },
+    { name: "Shopping", icon: ShoppingBag, category: "shopping" },
+    { name: "Museums", icon: Palette, category: "museum" },
+    { name: "Parks", icon: Trees, category: "park" },
+    { name: "Beaches", icon: Waves, category: "beach" },
+    { name: "Adventure", icon: Mountain, category: "adventure" },
+    { name: "Cultural", icon: Drama, category: "cultural" },
+    { name: "Markets", icon: Store, category: "market" },
   ];
+
+  const deliveredTraceKeys = new Set<string>();
 
   const normalizePoi = (poi: any): POI => ({
     id: poi.id || poi.llm_interaction_id || poi.name,
@@ -98,9 +118,55 @@ export default function DiscoverPage() {
     distance: poi.distance,
     city: poi.city || poi.city_name,
     city_id: poi.city_id || poi.cityId,
+    recommendation_rationale: poi.recommendation_rationale || poi.recommendationRationale,
     llm_interaction_id: poi.llm_interaction_id,
     created_at: poi.created_at,
+    recommendation_trace: normalizeRecommendationTrace(
+      poi.recommendation_trace || poi.recommendationTrace,
+    ),
   });
+
+  const attributeResults = (rawPOIs: any[]) => {
+    const list = rawPOIs.map(normalizePoi);
+    const newlyDelivered = list.filter((poi) => {
+      const trace = poi.recommendation_trace;
+      if (!trace) return false;
+      const key = `${trace.runId}:${trace.itemId}`;
+      if (deliveredTraceKeys.has(key)) return false;
+      deliveredTraceKeys.add(key);
+      return true;
+    });
+    void recordRecommendationEvents(
+      newlyDelivered.flatMap((poi) => [
+        {
+          eventType: "RECOMMENDATION_EVENT_TYPE_DELIVERED" as const,
+          trace: poi.recommendation_trace!,
+          poiId: poi.id,
+        },
+        {
+          eventType: "RECOMMENDATION_EVENT_TYPE_PRESENTED" as const,
+          trace: poi.recommendation_trace!,
+          poiId: poi.id,
+        },
+      ]),
+    );
+    return list;
+  };
+
+  const recordPoiOutcome = (
+    poi: POI,
+    eventType: "RECOMMENDATION_EVENT_TYPE_OPENED" | "RECOMMENDATION_EVENT_TYPE_DISMISSED",
+  ) => {
+    if (!poi.recommendation_trace) return;
+    void recordRecommendationEvents([
+      { eventType, trace: poi.recommendation_trace, poiId: poi.id },
+    ]);
+  };
+
+  const dismissPoi = (poi: POI) => {
+    recordPoiOutcome(poi, "RECOMMENDATION_EVENT_TYPE_DISMISSED");
+    setSearchResults((current) => current.filter((item) => item.id !== poi.id));
+  };
 
   const handleSearch = async (e?: Event) => {
     e?.preventDefault();
@@ -161,14 +227,14 @@ export default function DiscoverPage() {
           case "restaurants":
           case "hotels":
           case "activities": {
-            const list = event.pois.map(normalizePoi);
+            const list = attributeResults(event.pois);
             setSearchResults(list);
             localResultCache.set(cacheKey, list);
             setProgressMessage("Found places you might like");
             break;
           }
           case "itinerary": {
-            const pois = (event.cityResponse.points_of_interest || []).map(normalizePoi);
+            const pois = attributeResults(event.cityResponse.points_of_interest || []);
             if (pois.length > 0) setSearchResults(pois);
             setProgressMessage("Drafting an itinerary...");
             break;
@@ -434,7 +500,7 @@ export default function DiscoverPage() {
               </div>
 
               {/* Search Bar */}
-              <div class="glass-panel rounded-2xl p-6 shadow-lg border">
+              <div class="loci-card rounded-2xl p-6">
                 <form onSubmit={handleSearch} class="relative">
                   <div class="flex flex-col md:flex-row gap-4">
                     <div class="flex-1 relative">
@@ -524,7 +590,7 @@ export default function DiscoverPage() {
                     }
                   >
                     <For each={searchResults()}>
-                      {(poi) => {
+                      {(poi, index) => {
                         const itemForSelection: SelectionItem = {
                           id: poi.id || poi.name,
                           name: poi.name,
@@ -537,7 +603,8 @@ export default function DiscoverPage() {
                         };
                         return (
                           <div
-                            class={`glass-panel rounded-2xl p-4 hover:shadow-xl hover:scale-[1.02] transition-all duration-200 cursor-pointer ${selection.isSelected(poi.id || poi.name) ? "ring-2 ring-accent bg-accent/10" : ""}`}
+                            class={`loci-card-interactive stagger-animation rounded-xl p-4 ${selection.isSelected(poi.id || poi.name) ? "ring-2 ring-accent border-accent/40" : ""}`}
+                            style={{ "animation-delay": `${Math.min(index(), 19) * 0.05}s` }}
                           >
                             <div class="flex items-start justify-between gap-3 mb-2">
                               <div class="flex items-center gap-3 flex-1">
@@ -565,16 +632,34 @@ export default function DiscoverPage() {
                                     description: poi.description_poi || poi.description || "",
                                   }}
                                   size="sm"
+                                  recommendationTrace={poi.recommendation_trace}
+                                  poiId={poi.id}
                                 />
                                 <span class="loci-chip loci-chip--muted">
                                   {poi.city || "Unknown"}
                                 </span>
+                                <button
+                                  type="button"
+                                  class="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+                                  onClick={() => dismissPoi(poi)}
+                                  aria-label={`Dismiss ${poi.name}`}
+                                >
+                                  Dismiss
+                                </button>
                               </div>
                             </div>
-                            <p class="text-sm text-muted-foreground line-clamp-2 mb-3 leading-relaxed">
+                            <p class="text-sm text-muted-foreground line-clamp-2 mb-2 leading-relaxed">
                               {poi.description_poi || poi.description || "No description provided."}
                             </p>
-                            <div class="flex items-center gap-3 text-xs text-muted-foreground">
+                            <WhyThisStop
+                              reason={deriveWhyThis({
+                                category: poi.category,
+                                rating: poi.rating,
+                                recommendation_rationale: poi.recommendation_rationale,
+                                tags: poi.tags,
+                              })}
+                            />
+                            <div class="flex items-center gap-3 text-xs text-muted-foreground mt-3">
                               <div class="flex items-center gap-1">
                                 <Star class="w-4 h-4 text-accent fill-current" />
                                 <span class="font-medium">{poi.rating ?? "4.0"}</span>
@@ -583,6 +668,19 @@ export default function DiscoverPage() {
                                 <MapPin class="w-4 h-4 text-primary" />
                                 <span class="font-medium">{poi.city || "N/A"}</span>
                               </div>
+                              <Show when={poi.website}>
+                                <a
+                                  href={poi.website}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  class="ml-auto font-medium text-primary hover:underline"
+                                  onClick={() =>
+                                    recordPoiOutcome(poi, "RECOMMENDATION_EVENT_TYPE_OPENED")
+                                  }
+                                >
+                                  Open place
+                                </a>
+                              </Show>
                             </div>
                           </div>
                         );
@@ -605,10 +703,10 @@ export default function DiscoverPage() {
                 {(cat) => (
                   <button
                     onClick={() => handleCategoryClick(cat.category, cat.name)}
-                    class="glass-panel p-3 rounded-xl hover:shadow-lg hover:scale-105 hover:border-primary/30 transition-all duration-200 group text-center"
+                    class="loci-card-interactive p-3 rounded-xl group text-center min-h-[44px]"
                   >
-                    <span class="block text-2xl mb-1 group-hover:scale-110 transition-transform">
-                      {cat.emoji}
+                    <span class="mx-auto mb-1 flex h-8 w-8 items-center justify-center rounded-lg border border-border bg-secondary text-primary">
+                      <cat.icon class="h-4 w-4" aria-hidden="true" />
                     </span>
                     <span class="block text-xs font-semibold text-foreground">{cat.name}</span>
                   </button>
@@ -701,7 +799,7 @@ export default function DiscoverPage() {
                           {(item, index) => (
                             <button
                               onClick={() => handleTrendingClick(item)}
-                              class="w-full flex items-center gap-3 p-4 glass-panel rounded-xl hover:border-primary/30 hover:shadow-lg cursor-pointer transition-all duration-200 group"
+                              class="w-full flex items-center gap-3 p-4 loci-card-interactive rounded-xl group"
                             >
                               <div class="flex items-center justify-center w-8 h-8 bg-primary/10 text-primary rounded-full text-sm font-bold shadow-sm">
                                 {index() + 1}
@@ -753,7 +851,7 @@ export default function DiscoverPage() {
                           {(item) => (
                             <button
                               onClick={() => handleCategoryClick(item.category, item.title)}
-                              class="flex items-center gap-3 p-4 glass-panel rounded-xl hover:border-accent/30 hover:shadow-lg cursor-pointer transition-all duration-200 group"
+                              class="flex items-center gap-3 p-4 loci-card-interactive rounded-xl group"
                             >
                               <span class="text-3xl">{item.emoji}</span>
                               <div class="flex-1 text-left">
@@ -805,7 +903,7 @@ export default function DiscoverPage() {
                       <div class="space-y-3">
                         <For each={recentSessions()}>
                           {(session) => (
-                            <div class="glass-panel rounded-xl p-4 hover:shadow-lg hover:scale-[1.02] transition-all duration-200 cursor-pointer">
+                            <div class="loci-card-interactive rounded-xl p-4 cursor-pointer">
                               <div class="flex items-start gap-3 mb-3">
                                 <span class="text-2xl">🗺️</span>
                                 <div class="flex-1 min-w-0">

--- a/src/routes/hotels/index.tsx
+++ b/src/routes/hotels/index.tsx
@@ -193,7 +193,7 @@ export default function HotelsPage() {
 
   return (
     <>
-      <SplitView listContent={ListContent} mapContent={MapContent} initialMode="split" />
+      <SplitView listContent={ListContent} mapContent={MapContent} initialMode="map" />
       <FloatingChat
         getStreamingData={() => effectiveData()}
         setStreamingData={(fn) => {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -89,7 +89,7 @@ export default function Index() {
         when={!isLoading()}
         fallback={
           <div class="min-h-screen flex items-center justify-center">
-            <div class="glass-panel gradient-border rounded-2xl p-6 text-center shadow-lg">
+            <div class="loci-card rounded-2xl p-6 text-center shadow-lg">
               <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4" />
               <p class="text-muted-foreground font-medium">Loading...</p>
             </div>

--- a/src/routes/itinerary/index.tsx
+++ b/src/routes/itinerary/index.tsx
@@ -363,6 +363,7 @@ export default function ItineraryPage() {
           selectedId={selectedId()}
           onSelect={(poi) => setSelectedId(poi.name)}
           onActivate={(poi) => openDetail(poi)}
+          fullBleed
         />
       </Show>
 
@@ -443,7 +444,7 @@ export default function ItineraryPage() {
 
   return (
     <>
-      <SplitView listContent={ListContent} mapContent={MapContent} initialMode="split" />
+      <SplitView listContent={ListContent} mapContent={MapContent} initialMode="map" />
       <Show when={detailOpen()}>
         <DetailedItemModal
           item={detailItem()}

--- a/src/routes/lists/index.tsx
+++ b/src/routes/lists/index.tsx
@@ -217,17 +217,11 @@ export default function ListsPage() {
 
               {/* Quick Links */}
               <div class="flex items-center gap-3 flex-wrap">
-                <A
-                  href="/favorites"
-                  class="loci-hero__action px-4 py-2"
-                >
+                <A href="/favorites" class="loci-hero__action px-4 py-2">
                   <Heart class="w-4 h-4" />
                   View Favorites
                 </A>
-                <A
-                  href="/bookmarks"
-                  class="loci-hero__action px-4 py-2"
-                >
+                <A href="/bookmarks" class="loci-hero__action px-4 py-2">
                   <Bookmark class="w-4 h-4" />
                   View Bookmarks
                 </A>
@@ -310,7 +304,7 @@ export default function ListsPage() {
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               <For each={filteredLists()}>
                 {(list: any) => (
-                  <div class="glass-panel rounded-2xl p-5 hover:shadow-xl transition-all duration-200 group relative">
+                  <div class="loci-card-interactive stagger-animation rounded-2xl p-5 group relative">
                     {/* Delete Confirmation Overlay */}
                     <Show when={deleteConfirmId() === list.id}>
                       <div class="absolute inset-0 bg-card/95 backdrop-blur rounded-2xl flex flex-col items-center justify-center z-10 p-4">

--- a/src/routes/nearme/index.tsx
+++ b/src/routes/nearme/index.tsx
@@ -229,6 +229,7 @@ export default function NearmePage() {
           center={[userLocation()?.longitude || 0, userLocation()?.latitude || 0]}
           pointsOfInterest={allPois()}
           zoom={13}
+          fullBleed
         />
       </Show>
 
@@ -245,7 +246,7 @@ export default function NearmePage() {
 
   // List Content
   const ListContent = (
-    <div class="h-full overflow-y-auto p-4 md:p-6 bg-background/50 backdrop-blur-sm">
+    <div class="h-full overflow-y-auto p-4 md:p-6 bg-background">
       <div class="max-w-3xl mx-auto pb-20">
         {/* Location Header */}
         <div class="mb-6">
@@ -254,7 +255,7 @@ export default function NearmePage() {
               <Navigation class="w-6 h-6" />
             </div>
             <div>
-              <h1 class="text-2xl font-bold text-foreground">Near Me</h1>
+              <h1 class="font-serif text-2xl font-bold text-foreground">Near Me</h1>
               <Show when={userLocation()}>
                 <p class="text-sm text-muted-foreground">
                   {userLocation()?.latitude.toFixed(4)}, {userLocation()?.longitude.toFixed(4)}
@@ -323,9 +324,7 @@ export default function NearmePage() {
             <Loader2 class="w-6 h-6 animate-spin text-primary" />
             <div>
               <p class="font-medium text-primary">Getting your location...</p>
-              <p class="text-sm text-muted-foreground opacity-80">
-                This may take a few seconds
-              </p>
+              <p class="text-sm text-muted-foreground opacity-80">This may take a few seconds</p>
             </div>
           </div>
         </Show>
@@ -346,12 +345,13 @@ export default function NearmePage() {
         {/* Results */}
         <Show when={allPois().length > 0}>
           <div class="mb-8">
-            <h3 class="text-xl font-bold mb-4 text-foreground flex items-center gap-2">
-              <span class="text-2xl">📍</span> Nearby Places ({allPois().length})
+            <h3 class="font-serif text-xl font-bold mb-4 text-foreground flex items-center gap-2">
+              <MapPin class="h-5 w-5 text-accent" />
+              Nearby places ({allPois().length})
             </h3>
             <div class="space-y-4">
               <For each={allPois()}>
-                {(item) => {
+                {(item, index) => {
                   const itemForSelection: SelectionItem = {
                     id: item.name,
                     name: item.name,
@@ -364,7 +364,8 @@ export default function NearmePage() {
                   };
                   return (
                     <Card
-                      class={`hover:shadow-md transition-all cursor-pointer bg-card/80 backdrop-blur border-border ${selection.isSelected(item.name) ? "ring-2 ring-primary" : ""}`}
+                      class={`loci-card-interactive stagger-animation rounded-xl ${selection.isSelected(item.name) ? "ring-2 ring-accent border-accent/40" : ""}`}
+                      style={{ "animation-delay": `${Math.min(index(), 19) * 0.05}s` }}
                     >
                       <CardHeader>
                         <div class="flex justify-between items-start">
@@ -435,7 +436,7 @@ export default function NearmePage() {
 
   return (
     <>
-      <SplitView mapContent={MapContent} listContent={ListContent} />
+      <SplitView mapContent={MapContent} listContent={ListContent} initialMode="map" />
       <FloatingChat />
 
       {/* Selection Toolbar */}

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -217,7 +217,7 @@ export default function Pricing() {
           <PromoCodeSection onSuccess={handlePromoSuccess} />
 
           <Show when={appliedPromo()}>
-            <div class="max-w-3xl mx-auto glass-panel gradient-border rounded-2xl p-5 border-0">
+            <div class="max-w-3xl mx-auto loci-card rounded-2xl p-5">
               <p class="font-semibold text-foreground">Promo applied</p>
               <p class="text-muted-foreground text-sm">{appliedPromo()?.description}</p>
             </div>
@@ -495,7 +495,7 @@ export default function Pricing() {
             </article>
           </section>
 
-          <section class="text-center glass-panel gradient-border rounded-2xl p-12">
+          <section class="text-center loci-card rounded-2xl p-12">
             <h2 class="text-3xl font-bold mb-4">Ready when your trip is</h2>
             <p class="text-muted-foreground mb-8 max-w-xl mx-auto">
               Generate a plan free. Upgrade when you need every day on Maps and calendar.

--- a/src/routes/restaurants/index.tsx
+++ b/src/routes/restaurants/index.tsx
@@ -188,7 +188,7 @@ export default function RestaurantsPage() {
 
   return (
     <>
-      <SplitView listContent={ListContent} mapContent={MapContent} initialMode="split" />
+      <SplitView listContent={ListContent} mapContent={MapContent} initialMode="map" />
       <FloatingChat
         getStreamingData={() => effectiveData()}
         setStreamingData={(fn) => {

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -43,6 +43,7 @@ import InterestsComponent from "~/components/features/Settings/Interests";
 import TravelProfiles from "~/components/features/Settings/TravelProfiles";
 import AppearanceSettings from "~/components/AppearanceSettings";
 import ApiKeys from "~/components/features/Settings/ApiKeys";
+import TasteAndPrivacy from "~/components/features/Settings/TasteAndPrivacy";
 import { Button } from "~/ui/button";
 
 export default function SettingsPage() {
@@ -329,10 +330,14 @@ export default function SettingsPage() {
           </div>
         </div>
 
+        <div class="mb-6">
+          <TasteAndPrivacy />
+        </div>
+
         <div class="grid lg:grid-cols-3 gap-6">
           <div class="lg:col-span-2 space-y-6">
             {/* Personal Information */}
-            <div class="rounded-3xl bg-card/80 backdrop-blur border border-border shadow-sm p-6 sm:p-8">
+            <div class="loci-card rounded-3xl p-6 sm:p-8">
               <div class="flex items-start justify-between mb-4">
                 <div>
                   <h3 class="text-lg sm:text-xl font-semibold text-foreground">
@@ -466,7 +471,7 @@ export default function SettingsPage() {
           </div>
 
           <div class="space-y-6">
-            <div class="rounded-3xl bg-card/80 backdrop-blur border border-border shadow-sm p-6 sm:p-8">
+            <div class="loci-card rounded-3xl p-6 sm:p-8">
               <div class="flex items-center justify-between mb-3">
                 <div>
                   <p class="text-xs uppercase tracking-wide text-muted-foreground">
@@ -489,7 +494,7 @@ export default function SettingsPage() {
               </p>
             </div>
 
-            <div class="rounded-3xl bg-card/80 backdrop-blur border border-border shadow-sm p-6 sm:p-8">
+            <div class="loci-card rounded-3xl p-6 sm:p-8">
               <h4 class="text-lg font-semibold text-foreground mb-1">Appearance</h4>
               <p class="text-sm text-muted-foreground mb-4">
                 Theme and language sync across your devices when signed in.
@@ -497,7 +502,7 @@ export default function SettingsPage() {
               <AppearanceSettings />
             </div>
 
-            <div class="rounded-3xl bg-card/80 backdrop-blur border border-border shadow-sm p-6 sm:p-8 space-y-3">
+            <div class="loci-card rounded-3xl p-6 sm:p-8 space-y-3">
               <div class="flex items-center gap-2">
                 <Bell class="w-5 h-5 text-primary" />
                 <h4 class="text-sm font-semibold text-foreground">Quick actions</h4>
@@ -687,11 +692,7 @@ export default function SettingsPage() {
       case "profiles":
         return renderProfiles();
       case "apikeys":
-        return (
-          <ApiKeys
-            onNotification={(message, type) => setNotification({ message, type })}
-          />
-        );
+        return <ApiKeys onNotification={(message, type) => setNotification({ message, type })} />;
       default:
         return renderSettings();
     }
@@ -722,7 +723,7 @@ export default function SettingsPage() {
         <div class="flex flex-col lg:flex-row gap-4 lg:gap-8">
           {/* Mobile Tab Navigation */}
           <div class="lg:hidden">
-            <div class="bg-card/80 backdrop-blur rounded-2xl border border-border p-2 shadow-sm">
+            <div class="loci-card rounded-2xl p-2">
               <div class="flex overflow-x-auto space-x-2">
                 <For each={tabs}>
                   {(tab) => {
@@ -748,7 +749,7 @@ export default function SettingsPage() {
 
           {/* Desktop Tab Navigation */}
           <div class="hidden lg:block w-64 flex-shrink-0">
-            <div class="bg-card/80 backdrop-blur rounded-2xl border border-border p-3 sticky top-8 shadow-sm">
+            <div class="loci-card rounded-2xl p-3 sticky top-8">
               <nav class="space-y-1.5">
                 <For each={tabs}>
                   {(tab) => {

--- a/src/routes/trips/[id].tsx
+++ b/src/routes/trips/[id].tsx
@@ -25,6 +25,8 @@ import {
   recordRecommendationEvents,
   type RecommendationEventName,
 } from "~/lib/api/recommendations";
+import PlacePicker from "~/components/trip/PlacePicker";
+import type { POI } from "~/lib/api/types";
 
 const minutesToHHMM = (m?: number) => {
   if (m == null) return "";
@@ -63,9 +65,8 @@ export default function TripEditor() {
 
   const [shareUrl, setShareUrl] = createSignal<string | null>(null);
   const [conflict, setConflict] = createSignal(false);
-  const [newStopDrafts, setNewStopDrafts] = createSignal<
-    Record<string, { name: string; poiId: string }>
-  >({});
+  const [replacingStopID, setReplacingStopID] = createSignal<string | null>(null);
+  const [removeConfirmID, setRemoveConfirmID] = createSignal<string | null>(null);
 
   const trip = () => tripQuery.data as Trip | undefined;
   const version = () => trip()?.version ?? 0n;
@@ -130,15 +131,7 @@ export default function TripEditor() {
       { onSuccess: (r) => setShareUrl(r.shareUrl) },
     );
 
-  const updateNewStop = (dayID: string, patch: Partial<{ name: string; poiId: string }>) =>
-    setNewStopDrafts((current) => {
-      const existing = current[dayID] ?? { name: "", poiId: "" };
-      return { ...current, [dayID]: { ...existing, ...patch } };
-    });
-
-  const addStop = (day: TripDay) => {
-    const draft = newStopDrafts()[day.id];
-    if (!draft?.name.trim() || !draft.poiId.trim()) return;
+  const addStop = (day: TripDay, poi: POI) => {
     add.mutate(
       {
         tripId: params.id!,
@@ -146,32 +139,33 @@ export default function TripEditor() {
         baseVersion: version(),
         stop: {
           id: crypto.randomUUID(),
-          poiId: draft.poiId.trim(),
+          poiId: poi.id,
           orderIndex: day.stops.length,
-          name: draft.name.trim(),
-          notes: "Added manually",
+          name: poi.name,
+          notes: poi.description_poi || poi.description || "Added from place search",
         },
       },
       {
-        onSuccess: () => updateNewStop(day.id, { name: "", poiId: "" }),
         onError: onMutationError,
       },
     );
   };
 
   const removeStop = (stop: TripStop) => {
-    if (!window.confirm(`Remove ${stop.name} from this trip?`)) return;
+    if (removeConfirmID() !== stop.id) {
+      setRemoveConfirmID(stop.id);
+      return;
+    }
     remove.mutate(
       { tripId: params.id!, stop, baseVersion: version() },
-      { onError: onMutationError },
+      {
+        onSuccess: () => setRemoveConfirmID(null),
+        onError: onMutationError,
+      },
     );
   };
 
-  const replaceStop = (stop: TripStop) => {
-    const name = window.prompt("Replacement place name");
-    if (!name?.trim()) return;
-    const poiId = window.prompt("Canonical place ID");
-    if (!poiId?.trim()) return;
+  const replaceStop = (stop: TripStop, poi: POI) => {
     replace.mutate(
       {
         tripId: params.id!,
@@ -180,12 +174,16 @@ export default function TripEditor() {
         replacement: {
           ...stop,
           id: crypto.randomUUID(),
-          poiId: poiId.trim(),
-          name: name.trim(),
+          poiId: poi.id,
+          name: poi.name,
+          notes: poi.description_poi || poi.description || "Replaced from place search",
           recommendationTrace: undefined,
         },
       },
-      { onError: onMutationError },
+      {
+        onSuccess: () => setReplacingStopID(null),
+        onError: onMutationError,
+      },
     );
   };
 
@@ -397,18 +395,38 @@ export default function TripEditor() {
                             <button
                               type="button"
                               class="rounded-md border px-2 py-1 text-xs hover:bg-muted"
-                              onClick={() => replaceStop(stop)}
+                              onClick={() =>
+                                setReplacingStopID((current) =>
+                                  current === stop.id ? null : stop.id,
+                                )
+                              }
+                              aria-expanded={replacingStopID() === stop.id}
                             >
-                              Replace
+                              {replacingStopID() === stop.id ? "Close search" : "Replace"}
                             </button>
                             <button
                               type="button"
-                              class="rounded-md border border-destructive/40 px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+                              class={`rounded-md border px-2 py-1 text-xs transition-colors ${
+                                removeConfirmID() === stop.id
+                                  ? "border-destructive bg-destructive text-destructive-foreground"
+                                  : "border-destructive/40 text-destructive hover:bg-destructive/10"
+                              }`}
                               onClick={() => removeStop(stop)}
                             >
-                              Remove
+                              {removeConfirmID() === stop.id ? "Confirm remove" : "Remove"}
                             </button>
                           </div>
+                          <Show when={replacingStopID() === stop.id}>
+                            <div class="mt-3 pl-8">
+                              <PlacePicker
+                                cityName={t.cityName}
+                                label={`Replace ${stop.name}`}
+                                busy={replace.isPending}
+                                onSelect={(poi) => replaceStop(stop, poi)}
+                                onCancel={() => setReplacingStopID(null)}
+                              />
+                            </div>
+                          </Show>
                           <div class="mt-2 flex flex-wrap items-center gap-2 pl-8">
                             <WhyThisStop reason={stop.notes} />
                             <Show when={stop.recommendationTrace}>
@@ -476,35 +494,13 @@ export default function TripEditor() {
                       )}
                     </For>
                   </ol>
-                  <div class="mt-3 grid gap-2 rounded-md border border-dashed p-3 sm:grid-cols-[1fr_1fr_auto]">
-                    <input
-                      class="rounded-md border px-2 py-1.5 text-sm"
-                      placeholder="Place name"
-                      value={newStopDrafts()[day.id]?.name || ""}
-                      onInput={(event) =>
-                        updateNewStop(day.id, { name: event.currentTarget.value })
-                      }
+                  <div class="mt-3">
+                    <PlacePicker
+                      cityName={t.cityName}
+                      label={`Add another place to Day ${day.dayNumber}`}
+                      busy={add.isPending}
+                      onSelect={(poi) => addStop(day, poi)}
                     />
-                    <input
-                      class="rounded-md border px-2 py-1.5 text-sm"
-                      placeholder="Canonical place ID"
-                      value={newStopDrafts()[day.id]?.poiId || ""}
-                      onInput={(event) =>
-                        updateNewStop(day.id, { poiId: event.currentTarget.value })
-                      }
-                    />
-                    <button
-                      type="button"
-                      class="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
-                      disabled={
-                        !newStopDrafts()[day.id]?.name.trim() ||
-                        !newStopDrafts()[day.id]?.poiId.trim() ||
-                        add.isPending
-                      }
-                      onClick={() => addStop(day)}
-                    >
-                      Add stop
-                    </button>
                   </div>
                 </section>
               )}

--- a/src/routes/trips/[id].tsx
+++ b/src/routes/trips/[id].tsx
@@ -7,6 +7,9 @@ import {
   useEditStopDuration,
   useSetConstraint,
   useShareTrip,
+  useAddStop,
+  useRemoveStop,
+  useReplaceStop,
   type Trip,
   type TripDay,
   type TripStop,
@@ -18,6 +21,10 @@ import { isProPlan } from "~/lib/subscription";
 import TripExportMenu from "~/components/trip/TripExportMenu";
 import WhyThisStop from "~/components/poi/WhyThisStop";
 import { cacheTripOffline } from "~/lib/trip-offline-cache";
+import {
+  recordRecommendationEvents,
+  type RecommendationEventName,
+} from "~/lib/api/recommendations";
 
 const minutesToHHMM = (m?: number) => {
   if (m == null) return "";
@@ -50,9 +57,15 @@ export default function TripEditor() {
   const editDur = useEditStopDuration();
   const setConstraint = useSetConstraint();
   const share = useShareTrip();
+  const add = useAddStop();
+  const remove = useRemoveStop();
+  const replace = useReplaceStop();
 
   const [shareUrl, setShareUrl] = createSignal<string | null>(null);
   const [conflict, setConflict] = createSignal(false);
+  const [newStopDrafts, setNewStopDrafts] = createSignal<
+    Record<string, { name: string; poiId: string }>
+  >({});
 
   const trip = () => tripQuery.data as Trip | undefined;
   const version = () => trip()?.version ?? 0n;
@@ -116,6 +129,82 @@ export default function TripEditor() {
       { tripId: params.id!, isPublic: true },
       { onSuccess: (r) => setShareUrl(r.shareUrl) },
     );
+
+  const updateNewStop = (dayID: string, patch: Partial<{ name: string; poiId: string }>) =>
+    setNewStopDrafts((current) => {
+      const existing = current[dayID] ?? { name: "", poiId: "" };
+      return { ...current, [dayID]: { ...existing, ...patch } };
+    });
+
+  const addStop = (day: TripDay) => {
+    const draft = newStopDrafts()[day.id];
+    if (!draft?.name.trim() || !draft.poiId.trim()) return;
+    add.mutate(
+      {
+        tripId: params.id!,
+        dayId: day.id,
+        baseVersion: version(),
+        stop: {
+          id: crypto.randomUUID(),
+          poiId: draft.poiId.trim(),
+          orderIndex: day.stops.length,
+          name: draft.name.trim(),
+          notes: "Added manually",
+        },
+      },
+      {
+        onSuccess: () => updateNewStop(day.id, { name: "", poiId: "" }),
+        onError: onMutationError,
+      },
+    );
+  };
+
+  const removeStop = (stop: TripStop) => {
+    if (!window.confirm(`Remove ${stop.name} from this trip?`)) return;
+    remove.mutate(
+      { tripId: params.id!, stop, baseVersion: version() },
+      { onError: onMutationError },
+    );
+  };
+
+  const replaceStop = (stop: TripStop) => {
+    const name = window.prompt("Replacement place name");
+    if (!name?.trim()) return;
+    const poiId = window.prompt("Canonical place ID");
+    if (!poiId?.trim()) return;
+    replace.mutate(
+      {
+        tripId: params.id!,
+        currentStop: stop,
+        baseVersion: version(),
+        replacement: {
+          ...stop,
+          id: crypto.randomUUID(),
+          poiId: poiId.trim(),
+          name: name.trim(),
+          recommendationTrace: undefined,
+        },
+      },
+      { onError: onMutationError },
+    );
+  };
+
+  const recordStopOutcome = (
+    stop: TripStop,
+    eventType: RecommendationEventName,
+    rating?: number,
+  ) => {
+    if (!stop.recommendationTrace) return;
+    void recordRecommendationEvents([
+      {
+        eventType,
+        trace: stop.recommendationTrace,
+        poiId: stop.poiId,
+        tripId: params.id!,
+        rating,
+      },
+    ]);
+  };
 
   return (
     <main class="mx-auto max-w-3xl px-4 py-8">
@@ -305,14 +394,118 @@ export default function TripEditor() {
                               }
                             />
                             <span class="text-xs text-muted-foreground">min</span>
+                            <button
+                              type="button"
+                              class="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                              onClick={() => replaceStop(stop)}
+                            >
+                              Replace
+                            </button>
+                            <button
+                              type="button"
+                              class="rounded-md border border-destructive/40 px-2 py-1 text-xs text-destructive hover:bg-destructive/10"
+                              onClick={() => removeStop(stop)}
+                            >
+                              Remove
+                            </button>
                           </div>
-                          <div class="mt-1 pl-8">
+                          <div class="mt-2 flex flex-wrap items-center gap-2 pl-8">
                             <WhyThisStop reason={stop.notes} />
+                            <Show when={stop.recommendationTrace}>
+                              <button
+                                type="button"
+                                class="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                                onClick={() =>
+                                  recordStopOutcome(stop, "RECOMMENDATION_EVENT_TYPE_KEPT_IN_TRIP")
+                                }
+                              >
+                                Keep this stop
+                              </button>
+                              <button
+                                type="button"
+                                class="rounded-md border px-2 py-1 text-xs hover:bg-muted"
+                                onClick={() =>
+                                  recordStopOutcome(
+                                    stop,
+                                    "RECOMMENDATION_EVENT_TYPE_VISIT_CONFIRMED",
+                                  )
+                                }
+                              >
+                                Mark visited
+                              </button>
+                              <select
+                                class="rounded-md border px-2 py-1 text-xs"
+                                aria-label={`Rate ${stop.name}`}
+                                value=""
+                                onChange={(event) => {
+                                  const rating = Number(event.currentTarget.value);
+                                  if (rating > 0) {
+                                    recordStopOutcome(
+                                      stop,
+                                      "RECOMMENDATION_EVENT_TYPE_RATED",
+                                      rating,
+                                    );
+                                    event.currentTarget.value = "";
+                                  }
+                                }}
+                              >
+                                <option value="">Rate…</option>
+                                <For each={[1, 2, 3, 4, 5]}>
+                                  {(rating) => <option value={rating}>{rating} / 5</option>}
+                                </For>
+                              </select>
+                            </Show>
+                            <Show when={stop.bookingUrl}>
+                              <a
+                                href={stop.bookingUrl}
+                                target="_blank"
+                                rel="noreferrer"
+                                class="rounded-md border px-2 py-1 text-xs text-primary hover:bg-muted"
+                                onClick={() =>
+                                  recordStopOutcome(
+                                    stop,
+                                    "RECOMMENDATION_EVENT_TYPE_BOOKING_OPENED",
+                                  )
+                                }
+                              >
+                                Open booking
+                              </a>
+                            </Show>
                           </div>
                         </li>
                       )}
                     </For>
                   </ol>
+                  <div class="mt-3 grid gap-2 rounded-md border border-dashed p-3 sm:grid-cols-[1fr_1fr_auto]">
+                    <input
+                      class="rounded-md border px-2 py-1.5 text-sm"
+                      placeholder="Place name"
+                      value={newStopDrafts()[day.id]?.name || ""}
+                      onInput={(event) =>
+                        updateNewStop(day.id, { name: event.currentTarget.value })
+                      }
+                    />
+                    <input
+                      class="rounded-md border px-2 py-1.5 text-sm"
+                      placeholder="Canonical place ID"
+                      value={newStopDrafts()[day.id]?.poiId || ""}
+                      onInput={(event) =>
+                        updateNewStop(day.id, { poiId: event.currentTarget.value })
+                      }
+                    />
+                    <button
+                      type="button"
+                      class="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground disabled:opacity-50"
+                      disabled={
+                        !newStopDrafts()[day.id]?.name.trim() ||
+                        !newStopDrafts()[day.id]?.poiId.trim() ||
+                        add.isPending
+                      }
+                      onClick={() => addStop(day)}
+                    >
+                      Add stop
+                    </button>
+                  </div>
                 </section>
               )}
             </For>

--- a/src/routes/trips/index.tsx
+++ b/src/routes/trips/index.tsx
@@ -1,42 +1,91 @@
 import { For, Show } from "solid-js";
 import { A } from "@solidjs/router";
+import { ArrowRight, CalendarDays, Compass, MapPin, Plus } from "lucide-solid";
 import { useTrips } from "~/lib/api/trips";
+import { Button } from "~/ui/button";
 
 export default function TripsList() {
   const trips = useTrips();
 
   return (
-    <main class="mx-auto max-w-3xl px-4 py-8">
-      <h1 class="mb-6 text-2xl font-semibold">Your trips</h1>
+    <main class="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-12">
+      <section class="loci-hero mb-8">
+        <div class="loci-hero__content grid gap-8 p-6 sm:p-9 md:grid-cols-[1fr_auto] md:items-end">
+          <div>
+            <p class="font-coord mb-3 text-[10px] uppercase tracking-[0.2em] text-primary-foreground/65">
+              Expedition desk · {trips.data?.length || 0} routes
+            </p>
+            <h1 class="max-w-2xl text-4xl text-primary-foreground sm:text-5xl">
+              Your adventures, made workable.
+            </h1>
+            <p class="mt-4 max-w-xl text-sm leading-6 text-primary-foreground/72 sm:text-base">
+              Keep the places that feel right, move the rest, and leave with a day-by-day route you
+              can actually follow.
+            </p>
+          </div>
+          <A href="/discover">
+            <Button class="gap-2 border border-primary-foreground/25 bg-primary-foreground text-primary hover:bg-primary-foreground/90">
+              <Plus class="h-4 w-4" />
+              Plan a new trip
+            </Button>
+          </A>
+        </div>
+      </section>
 
       <Show when={trips.isLoading}>
-        <p class="text-muted-foreground">Loading…</p>
+        <div class="grid gap-4 md:grid-cols-2">
+          <For each={[1, 2, 3, 4]}>
+            {() => <div class="h-44 animate-pulse rounded-xl border border-border bg-card" />}
+          </For>
+        </div>
       </Show>
 
       <Show when={trips.data && trips.data.length === 0}>
-        <p class="text-muted-foreground">
-          No saved trips yet. Generate an itinerary and save it to start planning.
-        </p>
+        <section class="rounded-xl border border-dashed border-border bg-card/70 px-6 py-16 text-center">
+          <Compass class="mx-auto h-8 w-8 text-accent" />
+          <h2 class="mt-5 text-2xl">No route pinned yet</h2>
+          <p class="mx-auto mt-2 max-w-md text-sm text-muted-foreground">
+            Start with a city, a mood, or one place you refuse to miss. Loci will sketch the first
+            route and you can make it yours.
+          </p>
+          <A href="/discover" class="mt-6 inline-block">
+            <Button>Find your first stop</Button>
+          </A>
+        </section>
       </Show>
 
-      <ul class="space-y-3">
+      <ul class="grid gap-4 md:grid-cols-2">
         <For each={trips.data}>
-          {(t) => (
+          {(trip, index) => (
             <li>
               <A
-                href={`/trips/${t.id}`}
-                class="block rounded-lg border p-4 transition hover:bg-accent"
+                href={`/trips/${trip.id}`}
+                class="group block min-h-52 overflow-hidden loci-card-interactive rounded-xl"
               >
-                <div class="flex items-center justify-between">
-                  <span class="font-medium">{t.title}</span>
-                  <span class="text-sm text-muted-foreground">
-                    {t.days.length} day{t.days.length === 1 ? "" : "s"}
-                  </span>
+                <div class="flex h-full flex-col p-6">
+                  <div class="flex items-start justify-between gap-4">
+                    <span class="font-coord text-[10px] uppercase tracking-[0.18em] text-accent">
+                      Route {String(index() + 1).padStart(2, "0")}
+                    </span>
+                    <span class="rounded-full bg-secondary px-3 py-1 text-xs font-semibold text-secondary-foreground">
+                      {trip.days.length} day{trip.days.length === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                  <h2 class="mt-7 text-2xl leading-tight">{trip.title}</h2>
+                  <div class="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
+                    <MapPin class="h-4 w-4 text-accent" />
+                    {trip.cityName || "Open route"}
+                  </div>
+                  <div class="mt-auto flex items-end justify-between gap-4 pt-8">
+                    <span class="flex items-center gap-2 font-coord text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+                      <CalendarDays class="h-3.5 w-3.5" />
+                      Updated {new Date(trip.updatedAt).toLocaleDateString()}
+                    </span>
+                    <span class="grid h-9 w-9 place-items-center rounded-full border border-border transition group-hover:border-accent group-hover:bg-accent group-hover:text-accent-foreground">
+                      <ArrowRight class="h-4 w-4" />
+                    </span>
+                  </div>
                 </div>
-                <p class="text-sm text-muted-foreground">
-                  {t.cityName || "Unknown city"} · updated{" "}
-                  {new Date(t.updatedAt).toLocaleDateString()}
-                </p>
               </A>
             </li>
           )}

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -117,7 +117,12 @@
     color: hsl(var(--hero-foreground, 0 0% 100%));
     background: var(
       --hero-gradient,
-      linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--accent)) 45%, hsl(var(--primary) / 0.5) 100%)
+      linear-gradient(
+        135deg,
+        hsl(var(--primary)) 0%,
+        hsl(var(--accent)) 45%,
+        hsl(var(--primary) / 0.5) 100%
+      )
     );
     border-radius: 1.5rem;
     border: 1px solid hsl(var(--hero-foreground, 0 0% 100%) / 0.3);
@@ -130,9 +135,21 @@
     inset: 0;
     opacity: 0.35;
     background:
-      radial-gradient(circle at 20% 20%, hsl(var(--hero-foreground, 0 0% 100%) / 0.45), transparent 35%),
-      radial-gradient(circle at 80% 0%, hsl(var(--hero-foreground, 0 0% 100%) / 0.35), transparent 30%),
-      radial-gradient(circle at 50% 80%, hsl(var(--hero-foreground, 0 0% 100%) / 0.25), transparent 32%);
+      radial-gradient(
+        circle at 20% 20%,
+        hsl(var(--hero-foreground, 0 0% 100%) / 0.45),
+        transparent 35%
+      ),
+      radial-gradient(
+        circle at 80% 0%,
+        hsl(var(--hero-foreground, 0 0% 100%) / 0.35),
+        transparent 30%
+      ),
+      radial-gradient(
+        circle at 50% 80%,
+        hsl(var(--hero-foreground, 0 0% 100%) / 0.25),
+        transparent 32%
+      );
   }
 
   .loci-hero__content {
@@ -316,6 +333,113 @@
 
   [data-theme="loci"] .jb-tab-active::after {
     display: none;
+  }
+}
+
+@layer base {
+  body,
+  [data-theme="loci"] body,
+  [data-theme="classic"] body,
+  [data-theme="modern"] body {
+    font-family: "DM Sans", "Segoe UI", sans-serif;
+    font-weight: 400;
+    background-color: hsl(var(--background));
+    background-image: none;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  [data-theme="loci"] h1,
+  [data-theme="loci"] h2,
+  [data-theme="loci"] h3,
+  [data-theme="loci"] h4,
+  [data-theme="classic"] h1,
+  [data-theme="classic"] h2,
+  [data-theme="classic"] h3,
+  [data-theme="classic"] h4,
+  [data-theme="modern"] h1,
+  [data-theme="modern"] h2,
+  [data-theme="modern"] h3,
+  [data-theme="modern"] h4 {
+    font-family: "Fraunces", Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.025em;
+  }
+
+  :focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 3px;
+  }
+
+  ::selection {
+    background: hsl(var(--accent) / 0.24);
+  }
+
+  .font-coord,
+  .kicker,
+  .ui-label,
+  .card-kicker {
+    font-family: "Space Mono", ui-monospace, monospace;
+  }
+
+  .loci-hero {
+    border-radius: 0.9rem;
+    border-color: hsl(var(--primary-foreground) / 0.18);
+    box-shadow: 0 18px 50px hsl(var(--foreground) / 0.15);
+  }
+
+  .loci-hero::before {
+    opacity: 0.2;
+    background-image:
+      radial-gradient(
+        circle at 86% 22%,
+        transparent 0 78px,
+        hsl(var(--hero-foreground) / 0.25) 79px 80px,
+        transparent 81px
+      ),
+      radial-gradient(
+        circle at 86% 22%,
+        transparent 0 128px,
+        hsl(var(--hero-foreground) / 0.16) 129px 130px,
+        transparent 131px
+      ),
+      radial-gradient(
+        circle at 8% 112%,
+        transparent 0 160px,
+        hsl(var(--hero-foreground) / 0.14) 161px 162px,
+        transparent 163px
+      );
+  }
+
+  .loci-card,
+  .editorial-card,
+  .glass-panel,
+  .island-panel {
+    border-radius: 0.8rem;
+    box-shadow: 0 8px 24px -18px hsl(var(--foreground) / 0.35);
+    backdrop-filter: none;
+  }
+
+  .island-nav {
+    margin: 0;
+    border-width: 0 0 1px;
+    border-radius: 0;
+    background: hsl(var(--background) / 0.94);
+    box-shadow: 0 6px 20px -18px hsl(var(--foreground) / 0.5);
+  }
+
+  .dark .island-nav {
+    background: hsl(var(--background) / 0.94);
+    border-color: hsl(var(--border));
+  }
+
+  [data-theme="loci"] .jb-tab-active {
+    color: hsl(var(--foreground));
+    background: hsl(var(--secondary));
+    border-radius: 0.55rem;
   }
 }
 

--- a/src/styles/motion-tokens.css
+++ b/src/styles/motion-tokens.css
@@ -27,12 +27,17 @@
     transform: scale(0.98);
   }
 
-  .loci-card {
-    @apply bg-card border border-border text-card-foreground;
+  .loci-card-interactive {
+    @apply cursor-pointer border border-border bg-card text-card-foreground;
+    transition:
+      transform var(--motion-base) var(--ease-settle),
+      opacity var(--motion-base) var(--ease-settle),
+      border-color var(--motion-fast) var(--ease-press),
+      background-color var(--motion-fast) var(--ease-press);
   }
 
-  .loci-card-interactive {
-    @apply loci-card motion-settle motion-press cursor-pointer;
+  .loci-card-interactive:active {
+    transform: scale(0.98);
   }
 
   .loci-card-interactive:hover {

--- a/src/styles/motion-tokens.css
+++ b/src/styles/motion-tokens.css
@@ -1,0 +1,72 @@
+@layer base {
+  :root {
+    --motion-fast: 150ms;
+    --motion-base: 250ms;
+    --motion-slow: 400ms;
+    --motion-route: 800ms;
+    --ease-settle: cubic-bezier(0.22, 1, 0.36, 1);
+    --ease-enter: cubic-bezier(0.16, 1, 0.3, 1);
+    --ease-press: cubic-bezier(0.4, 0, 0.2, 1);
+  }
+}
+
+@layer utilities {
+  .motion-enter {
+    animation: fadeIn var(--motion-base) var(--ease-enter) forwards;
+  }
+
+  .motion-settle {
+    transition:
+      transform var(--motion-base) var(--ease-settle),
+      opacity var(--motion-base) var(--ease-settle),
+      border-color var(--motion-fast) var(--ease-press),
+      background-color var(--motion-fast) var(--ease-press);
+  }
+
+  .motion-press:active {
+    transform: scale(0.98);
+  }
+
+  .loci-card {
+    @apply bg-card border border-border text-card-foreground;
+  }
+
+  .loci-card-interactive {
+    @apply loci-card motion-settle motion-press cursor-pointer;
+  }
+
+  .loci-card-interactive:hover {
+    border-color: hsl(var(--primary) / 0.35);
+    box-shadow: 0 10px 28px -20px hsl(var(--foreground) / 0.4);
+  }
+
+  .island-panel {
+    @apply bg-card/95 border border-border;
+    box-shadow: 0 8px 32px -16px hsl(var(--foreground) / 0.18);
+  }
+
+  .dark .island-panel {
+    box-shadow: 0 12px 40px -12px hsl(0 0% 0% / 0.45);
+  }
+
+  .trust-chip {
+    @apply inline-flex max-w-full items-start gap-1.5 rounded-md border border-primary/20 bg-primary/5 px-2 py-1 text-xs text-foreground/80;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stagger-animation,
+  .progressive-fade-in,
+  .scale-in,
+  .motion-enter {
+    animation: none !important;
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .motion-settle,
+  .motion-press:active {
+    transition: none !important;
+    transform: none !important;
+  }
+}

--- a/src/styles/theme-utilities.css
+++ b/src/styles/theme-utilities.css
@@ -8,12 +8,13 @@
   }
 
   .glass-panel {
-    @apply bg-card/95 border border-border backdrop-blur-xl;
-    box-shadow: 0 4px 24px hsl(var(--foreground) / 0.06);
+    @apply bg-card border border-border;
+    box-shadow: 0 8px 24px -18px hsl(var(--foreground) / 0.35);
+    backdrop-filter: none;
   }
 
   .dark .glass-panel {
-    box-shadow: 0 4px 32px hsl(var(--foreground) / 0.15);
+    box-shadow: 0 12px 32px -12px hsl(0 0% 0% / 0.35);
   }
 
   .gradient-border {

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,404 +1,65 @@
 @layer base {
-  /* Enhanced Catppuccin Latte palette for light mode with improved accessibility */
-  :root {
-    --background: 220 23% 97%;
-    /* Lighter base for better contrast */
-    --foreground: 234 20% 28%;
-    /* Darker text for 7:1 contrast ratio */
-
-    --card: 220 22% 94%;
-    /* Slightly lighter mantle */
-    --card-foreground: 234 20% 28%;
-
-    --popover: 220 21% 92%;
-    /* Lighter crust */
-    --popover-foreground: 234 20% 28%;
-
-    --primary: 220 91% 48%;
-    /* Slightly darker blue for better contrast (5.5:1) */
-    --primary-foreground: 0 0% 100%;
-
-    --secondary: 197 87% 42%;
-    /* Adjusted sky blue for better contrast (4.8:1) */
-    --secondary-foreground: 0 0% 100%;
-
-    --muted: 225 14% 88%;
-    /* Lighter muted for glass backgrounds */
-    --muted-foreground: 233 16% 40%;
-    /* Darker muted text for 5.2:1 contrast */
-
-    --accent: 35 77% 45%;
-    /* Slightly darker yellow for better contrast */
-    --accent-foreground: 234 20% 20%;
-
-    --destructive: 347 87% 40%;
-    /* Darker red for better contrast (4.7:1) */
-    --destructive-foreground: 0 0% 98%;
-
-    --border: 223 20% 76%;
-    /* More visible border (3.2:1) */
-    --input: 223 20% 78%;
-    --ring: 109 58% 38%;
-    /* Slightly darker green for focus ring */
-
-    --radius: 1.25rem;
-
-    /* Hero banners always use dark gradients — foreground stays light across themes */
-    --hero-foreground: 0 0% 100%;
-  }
-
-  /* ========================================
-     CLASSIC Theme (Editorial Luxury)
-     ======================================== */
-
-  /* Classic Light Mode */
-  [data-theme="classic"] {
-    --background: 40 33% 96%;
-    /* Warm cream */
-    --foreground: 30 10% 20%;
-    /* Deep brown-black */
-
-    --card: 40 30% 93%;
-    --card-foreground: 30 10% 20%;
-
-    --popover: 40 25% 90%;
-    --popover-foreground: 30 10% 20%;
-
-    --primary: 30 60% 35%;
-    /* Rich brown/gold */
-    --primary-foreground: 40 33% 96%;
-
-    --secondary: 40 20% 85%;
-    --secondary-foreground: 30 10% 25%;
-
-    --muted: 40 15% 88%;
-    --muted-foreground: 30 8% 45%;
-
-    --accent: 25 70% 40%;
-    /* Warm amber */
-    --accent-foreground: 40 33% 96%;
-
-    --destructive: 0 70% 45%;
-    --destructive-foreground: 0 0% 98%;
-
-    --border: 40 15% 78%;
-    --input: 40 15% 80%;
-    --ring: 30 60% 35%;
-    --theme-color: #8a6e2f;
-
-    --hero-gradient: linear-gradient(135deg, #8a6e2f 0%, #d4af37 45%, #3d2b0f 100%);
-    --hero-glow: linear-gradient(
-      to top right,
-      rgba(212, 175, 55, 0.6),
-      rgba(245, 158, 11, 0.6),
-      rgba(180, 83, 9, 0.6)
-    );
-  }
-
-  /* Classic Dark Mode */
-  [data-theme="classic"].dark,
-  .dark [data-theme="classic"],
-  [data-theme="classic"][data-kb-theme="dark"] {
-    --background: 30 15% 10%;
-    /* Deep warm brown */
-    --foreground: 40 20% 90%;
-    /* Warm off-white */
-
-    --card: 30 12% 14%;
-    --card-foreground: 40 20% 90%;
-
-    --popover: 30 12% 12%;
-    --popover-foreground: 40 20% 90%;
-
-    --primary: 35 70% 55%;
-    /* Bright gold */
-    --primary-foreground: 30 15% 10%;
-
-    --secondary: 30 10% 20%;
-    --secondary-foreground: 40 20% 90%;
-
-    --muted: 30 10% 18%;
-    --muted-foreground: 40 15% 65%;
-
-    --accent: 35 80% 50%;
-    --accent-foreground: 30 15% 10%;
-
-    --destructive: 0 65% 50%;
-    --destructive-foreground: 0 0% 98%;
-
-    --border: 30 10% 22%;
-    --input: 30 10% 22%;
-    --ring: 35 70% 55%;
-    --theme-color: #5c4033;
-
-    --hero-gradient: linear-gradient(135deg, #5c4033 0%, #78350f 45%, #451a03 100%);
-    --hero-glow: linear-gradient(
-      to top right,
-      rgba(146, 64, 14, 0.6),
-      rgba(180, 83, 9, 0.6),
-      rgba(120, 53, 15, 0.6)
-    );
-  }
-
-  /* ========================================
-     MODERN Theme (Super-App / Functional)
-     ======================================== */
-
-  /* Modern Light Mode */
+  :root,
+  [data-theme="loci"],
+  [data-theme="classic"],
   [data-theme="modern"] {
-    --background: 210 20% 98%;
-    /* Cool neutral white */
-    --foreground: 220 15% 15%;
-    /* Near-black */
-
-    --card: 210 18% 95%;
-    --card-foreground: 220 15% 15%;
-
-    --popover: 210 15% 93%;
-    --popover-foreground: 220 15% 15%;
-
-    --primary: 220 90% 50%;
-    /* Vibrant blue */
-    --primary-foreground: 0 0% 100%;
-
-    --secondary: 210 15% 90%;
-    --secondary-foreground: 220 15% 20%;
-
-    --muted: 210 12% 88%;
-    --muted-foreground: 220 10% 45%;
-
-    --accent: 200 85% 45%;
-    /* Bright teal-blue */
-    --accent-foreground: 0 0% 100%;
-
-    --destructive: 0 85% 50%;
-    --destructive-foreground: 0 0% 98%;
-
-    --border: 210 15% 82%;
-    --input: 210 15% 85%;
-    --ring: 220 90% 50%;
-    --theme-color: #0c7df2;
-
-    /* Hero Theme vars */
-    --hero-gradient: linear-gradient(135deg, #0c7df2 0%, #6aa5ff 45%, #0c1747 100%);
-    --hero-glow: linear-gradient(
-      to top right,
-      rgba(59, 130, 246, 0.6),
-      rgba(6, 182, 212, 0.6),
-      rgba(147, 51, 234, 0.6)
-    );
+    --background: 43 38% 94%;
+    --foreground: 157 28% 14%;
+    --card: 42 44% 98%;
+    --card-foreground: 157 28% 14%;
+    --popover: 42 44% 98%;
+    --popover-foreground: 157 28% 14%;
+    --primary: 157 35% 20%;
+    --primary-foreground: 42 44% 98%;
+    --secondary: 91 18% 84%;
+    --secondary-foreground: 157 28% 16%;
+    --muted: 40 23% 88%;
+    --muted-foreground: 151 10% 39%;
+    --accent: 16 52% 48%;
+    --accent-foreground: 42 44% 98%;
+    --destructive: 2 58% 44%;
+    --destructive-foreground: 42 44% 98%;
+    --border: 42 18% 75%;
+    --input: 42 18% 75%;
+    --ring: 16 52% 48%;
+    --radius: 0.8rem;
+    --theme-color: #294d3c;
+    --hero-foreground: 43 38% 94%;
+    --hero-gradient: hsl(157 35% 20%);
+    --hero-glow: none;
+    --map-line: 153 15% 54%;
+    color-scheme: light;
   }
 
-  /* Modern Dark Mode */
-  [data-theme="modern"].dark,
-  .dark [data-theme="modern"],
-  [data-theme="modern"][data-kb-theme="dark"] {
-    --background: 220 25% 8%;
-    /* Deep navy */
-    --foreground: 210 20% 95%;
-    /* Bright white */
-
-    --card: 220 22% 12%;
-    --card-foreground: 210 20% 95%;
-
-    --popover: 220 22% 10%;
-    --popover-foreground: 210 20% 95%;
-
-    --primary: 220 95% 65%;
-    /* Bright blue */
-    --primary-foreground: 220 25% 8%;
-
-    --secondary: 220 18% 18%;
-    --secondary-foreground: 210 20% 95%;
-
-    --muted: 220 15% 15%;
-    --muted-foreground: 210 15% 65%;
-
-    --accent: 200 90% 55%;
-    --accent-foreground: 220 25% 8%;
-
-    --destructive: 0 70% 55%;
-    --destructive-foreground: 0 0% 98%;
-
-    --border: 220 18% 20%;
-    --input: 220 18% 20%;
-    --ring: 220 95% 65%;
-    --theme-color: #1e3a8a;
-
-    --hero-gradient: linear-gradient(135deg, #0f172a 0%, #1e40af 45%, #020617 100%);
-    --hero-glow: linear-gradient(
-      to top right,
-      rgba(30, 64, 175, 0.6),
-      rgba(59, 130, 246, 0.6),
-      rgba(30, 58, 138, 0.6)
-    );
-  }
-
-  /* ========================================
-     LOCI Theme (Premium / Copilot-Inspired)
-     ======================================== */
-
-  /* Loci Light Mode */
-  [data-theme="loci"] {
-    --background: 0 0% 99%;
-    /* Clean white */
-    --foreground: 0 0% 10%;
-    /* Soft black */
-
-    --card: 0 0% 97%;
-    --card-foreground: 0 0% 10%;
-
-    --popover: 0 0% 96%;
-    --popover-foreground: 0 0% 10%;
-
-    --primary: 0 0% 10%;
-    /* Near-black primary */
-    --primary-foreground: 0 0% 99%;
-
-    --secondary: 0 0% 94%;
-    --secondary-foreground: 0 0% 15%;
-
-    --muted: 0 0% 92%;
-    --muted-foreground: 0 0% 45%;
-
-    --accent: 160 50% 38%;
-    /* Softer teal accent */
-    --accent-foreground: 0 0% 99%;
-
-    --destructive: 0 65% 48%;
-    --destructive-foreground: 0 0% 99%;
-
-    --border: 0 0% 88%;
-    --input: 0 0% 90%;
-    --radius: 1rem;
-    --theme-color: #1a1a1a;
-
-    --hero-gradient: linear-gradient(160deg, #0a0a0a 0%, #1a1a1a 50%, #0a0a0a 100%);
-    --hero-glow: linear-gradient(
-      to top right,
-      rgba(16, 185, 129, 0.4),
-      rgba(20, 184, 166, 0.3),
-      rgba(6, 182, 212, 0.3)
-    );
-  }
-
-  /* Loci Dark Mode */
+  .dark,
+  [data-kb-theme="dark"],
   [data-theme="loci"].dark,
-  .dark [data-theme="loci"],
-  [data-theme="loci"][data-kb-theme="dark"] {
-    --background: 0 0% 4%;
-    /* Deep black like Copilot */
-    --foreground: 0 0% 96%;
-    /* Clean white */
-
-    --card: 0 0% 7%;
-    --card-foreground: 0 0% 96%;
-
-    --popover: 0 0% 6%;
-    --popover-foreground: 0 0% 96%;
-
-    --primary: 0 0% 96%;
-    /* Near-white primary */
-    --primary-foreground: 0 0% 4%;
-
-    --secondary: 0 0% 12%;
-    --secondary-foreground: 0 0% 96%;
-
-    --muted: 0 0% 10%;
-    --muted-foreground: 0 0% 55%;
-
-    --accent: 160 55% 42%;
-    /* Softer teal for dark */
-    --accent-foreground: 0 0% 4%;
-
-    --destructive: 0 60% 50%;
-    --destructive-foreground: 0 0% 99%;
-
-    --border: 0 0% 14%;
-    --input: 0 0% 14%;
-    --ring: 0 0% 96%;
-    --radius: 1rem;
-    --theme-color: #0a0a0a;
-
-    --hero-gradient: linear-gradient(160deg, #000000 0%, #0a0a0a 50%, #050505 100%);
-    --hero-glow: linear-gradient(
-      to top right,
-      rgba(16, 185, 129, 0.25),
-      rgba(20, 184, 166, 0.2),
-      rgba(6, 182, 212, 0.2)
-    );
-  }
-
-  .dark {
-    --background: 225 45% 6%;
-    /* Slightly lighter for better contrast foundation */
-    --foreground: 210 40% 98%;
-    /* Brighter white for 15.8:1 contrast (AAA) */
-
-    --card: 225 42% 10%;
-    /* Slightly lighter card background */
-    --card-foreground: 210 40% 98%;
-
-    --popover: 225 42% 10%;
-    --popover-foreground: 210 40% 98%;
-
-    --primary: 186 93% 68%;
-    /* Brighter cyan for 8.2:1 contrast (AAA) */
-    --primary-foreground: 0 0% 10%;
-    /* Darker for better contrast on cyan */
-
-    --secondary: 262 73% 20%;
-    /* Lighter purple for better visibility */
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 224 35% 15%;
-    /* Lighter muted background */
-    --muted-foreground: 220 17% 75%;
-    /* Brighter muted text for 6.8:1 contrast (AA+) */
-
-    --accent: 171 78% 50%;
-    /* Brighter teal for 5.1:1 contrast (AA) */
-    --accent-foreground: 0 0% 10%;
-
-    --destructive: 0 62.8% 45%;
-    /* Brighter red for 4.6:1 contrast (AA) */
-    --destructive-foreground: 0 0% 100%;
-
-    --border: 220 25% 22%;
-    /* More visible borders 2.8:1 */
-    --input: 220 25% 22%;
-    --ring: 186 93% 68%;
-    /* Match primary for consistency */
-  }
-
-  [data-kb-theme="dark"] {
-    --background: 240 10% 3.9%;
-    --foreground: 0 0% 98%;
-
-    --card: 240 10% 3.9%;
-    --card-foreground: 0 0% 98%;
-
-    --popover: 240 10% 3.9%;
-    --popover-foreground: 0 0% 98%;
-
-    --primary: 0 0% 98%;
-    --primary-foreground: 240 5.9% 10%;
-
-    --secondary: 240 3.7% 15.9%;
-    --secondary-foreground: 0 0% 98%;
-
-    --muted: 240 3.7% 15.9%;
-    --muted-foreground: 240 5% 64.9%;
-
-    --accent: 240 3.7% 15.9%;
-    --accent-foreground: 0 0% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 0 0% 98%;
-
-    --border: 240 3.7% 15.9%;
-    --input: 240 3.7% 15.9%;
-    --ring: 240 4.9% 83.9%;
-    --radius: 0.875rem;
+  [data-theme="classic"].dark,
+  [data-theme="modern"].dark {
+    --background: 157 22% 8%;
+    --foreground: 42 30% 91%;
+    --card: 157 20% 11%;
+    --card-foreground: 42 30% 91%;
+    --popover: 157 20% 10%;
+    --popover-foreground: 42 30% 91%;
+    --primary: 88 21% 68%;
+    --primary-foreground: 157 25% 10%;
+    --secondary: 156 15% 18%;
+    --secondary-foreground: 42 30% 91%;
+    --muted: 156 14% 16%;
+    --muted-foreground: 45 12% 66%;
+    --accent: 20 60% 61%;
+    --accent-foreground: 157 25% 9%;
+    --destructive: 2 54% 58%;
+    --destructive-foreground: 42 30% 94%;
+    --border: 154 12% 25%;
+    --input: 154 12% 25%;
+    --ring: 20 60% 61%;
+    --theme-color: #14251e;
+    --hero-foreground: 42 30% 93%;
+    --hero-gradient: hsl(157 29% 14%);
+    --hero-glow: none;
+    --map-line: 87 12% 40%;
+    color-scheme: dark;
   }
 }


### PR DESCRIPTION
## What changed

- gives the app a cohesive Loci travel, recommendation, and adventure visual language
- records recommendation outcomes across Discover, favorites, lists, trips, and exports
- adds taste/privacy controls, place intelligence, editable trip actions, and contributor surfaces
- lets every Discover card add directly to a chosen trip day
- replaces raw canonical-ID controls and browser prompts with inline place search, replacement, and removal flows

## Why

The product should feel like a travel companion while turning meaningful actions into measurable recommendation feedback and editable adventures.

## Impact

Users can discover, understand, save, and organize canonical places without leaving the travel flow.

## Checks

- `pnpm exec vitest run` — 156 tests
- `pnpm typecheck`
- `pnpm build`
- targeted oxlint
- visual browser click-through unavailable in this environment; production build is verified
